### PR TITLE
Add focuspoint gravity to imgproxy url if focusArea is present in processing configuration

### DIFF
--- a/Classes/ImageService/ImgProxyImageService.php
+++ b/Classes/ImageService/ImgProxyImageService.php
@@ -6,7 +6,9 @@ namespace SomehowDigital\Typo3\MediaProcessing\ImageService;
 
 use SomehowDigital\Typo3\MediaProcessing\UriBuilder\ImgProxyUri;
 use SomehowDigital\Typo3\MediaProcessing\UriBuilder\UriSourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Utility\FocusAreaUtility;
 use TYPO3\CMS\Core\Imaging\ImageDimension;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
 use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
 
 class ImgProxyImageService extends ImageServiceAbstract
@@ -122,6 +124,14 @@ class ImgProxyImageService extends ImageServiceAbstract
 					(int) $configuration['crop']->getOffsetTop(),
 				],
 			);
+		}
+
+		$focusArea = $configuration['focusArea'] ?? false;
+		if ($focusArea instanceof Area && !$focusArea->isEmpty()) {
+			$focusPointX = FocusAreaUtility::calculateCenter($focusArea->getOffsetLeft(), $focusArea->getWidth());
+			$focusPointY = FocusAreaUtility::calculateCenter($focusArea->getOffsetTop(), $focusArea->getHeight());
+
+			$uri->setGravity('fp', (float)$focusPointX, (float)$focusPointY);
 		}
 
 		if (isset($configuration['width']) || isset($configuration['maxWidth'])) {

--- a/Classes/ImageService/ImgProxyImageService.php
+++ b/Classes/ImageService/ImgProxyImageService.php
@@ -126,13 +126,18 @@ class ImgProxyImageService extends ImageServiceAbstract
 			);
 		}
 
-		$focusArea = $configuration['focusArea'] ?? false;
-		if ($focusArea instanceof Area && !$focusArea->isEmpty()) {
-			$focusPointX = FocusAreaUtility::calculateCenter($focusArea->getOffsetLeft(), $focusArea->getWidth());
-			$focusPointY = FocusAreaUtility::calculateCenter($focusArea->getOffsetTop(), $focusArea->getHeight());
-
-			$uri->setGravity('fp', (float)$focusPointX, (float)$focusPointY);
+		if (isset($configuration['focusArea']) && !$configuration['focusArea']->isEmpty()) {
+			$horizontalOffset = FocusAreaUtility::calculateCenter(
+				$configuration['focusArea']->getOffsetLeft(),
+				$configuration['focusArea']->getWidth(),
+			);
+			$verticalOffset = FocusAreaUtility::calculateCenter(
+				$configuration['focusArea']->getOffsetTop(),
+				$configuration['focusArea']->getHeight(),
+			);
+			$uri->setGravity('fp', $horizontalOffset, $verticalOffset);
 		}
+
 
 		if (isset($configuration['width']) || isset($configuration['maxWidth'])) {
 			$uri->setWidth((int) ($configuration['width'] ?? $configuration['maxWidth']));

--- a/Classes/UriBuilder/ImgProxyUri.php
+++ b/Classes/UriBuilder/ImgProxyUri.php
@@ -99,9 +99,9 @@ class ImgProxyUri implements UriInterface
 		return $this->type;
 	}
 
-	public function setGravity(string $type, ?int $horizontalOffset, ?int $verticalOffset): self
+	public function setGravity(string $type, ?float $horizontalOffset, ?float $verticalOffset): self
 	{
-		$this->gravity = array_filter([$type, $horizontalOffset, $verticalOffset]);
+		$this->gravity = [$type, $horizontalOffset, $verticalOffset];
 
 		return $this;
 	}

--- a/Classes/Utility/FocusAreaUtility.php
+++ b/Classes/Utility/FocusAreaUtility.php
@@ -6,15 +6,8 @@ use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
 
 class FocusAreaUtility
 {
-
-	/**
-	 * @param \TYPO3\CMS\Core\Imaging\ImageManipulation\Area $area
-	 *
-	 * @return float|int
-	 */
 	public static function calculateCenter(float $position, float $size)
 	{
-		// The max method ensures that only positive floats are returned
 		return max(($position + ($size / 2)), 0);
 	}
 }

--- a/Classes/Utility/FocusAreaUtility.php
+++ b/Classes/Utility/FocusAreaUtility.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SomehowDigital\Typo3\MediaProcessing\Utility;
+
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+
+class FocusAreaUtility
+{
+
+	/**
+	 * @param \TYPO3\CMS\Core\Imaging\ImageManipulation\Area $area
+	 *
+	 * @return float|int
+	 */
+	public static function calculateCenter(float $position, float $size)
+	{
+		// The max method ensures that only positive floats are returned
+		return max(($position + ($size / 2)), 0);
+	}
+}


### PR DESCRIPTION
Related Issue: https://github.com/somehow-digital/typo3-media-processing/issues/9

Hello, as mentioned in the issue a few weeks ago I prepared a pull request which passes down the focuspoint from the processing configuration to the imgproxy url.

Please let me know what you think about this and if you wan't me to do any optimizations. It would be great if this change could make it to your package.


Regards,
Cyrill