### PR TITLE
[BUGFIX] Removes array_filter to avoid invalid gravity options in ImgProxyUri

### DIFF
--- a/Classes/UriBuilder/ImgProxyUri.php
+++ b/Classes/UriBuilder/ImgProxyUri.php
@@ -161,7 +161,7 @@ class ImgProxyUri implements UriInterface
 
 	public function setCrop(int $width, int $height, array $gravity): self
 	{
-		$this->crop = array_filter([$width, $height, ...$gravity]);
+		$this->crop = [$width, $height, ...$gravity];
 
 		return $this;
 	}


### PR DESCRIPTION
This fixes the following issue:
https://github.com/somehow-digital/typo3-media-processing/issues/14