### PR TITLE
[TASK] Type check for imgproxy crop object

### DIFF
--- a/Classes/ImageService/ImgProxyImageService.php
+++ b/Classes/ImageService/ImgProxyImageService.php
@@ -8,6 +8,7 @@ use SomehowDigital\Typo3\MediaProcessing\UriBuilder\ImgProxyUri;
 use SomehowDigital\Typo3\MediaProcessing\UriBuilder\UriSourceInterface;
 use SomehowDigital\Typo3\MediaProcessing\Utility\FocusAreaUtility;
 use TYPO3\CMS\Core\Imaging\ImageDimension;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
 use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
 
 class ImgProxyImageService extends ImageServiceAbstract
@@ -113,7 +114,7 @@ class ImgProxyImageService extends ImageServiceAbstract
 
 		$uri->setType($type);
 
-		if (isset($configuration['crop'])) {
+		if (isset($configuration['crop']) && $configuration['crop'] instanceof Area) {
 			$uri->setCrop(
 				(int) $configuration['crop']->getWidth(),
 				(int) $configuration['crop']->getHeight(),


### PR DESCRIPTION
Check if crop configuration is an instance of the expected class to avoid a type error.