### PR TITLE
Ignore files without defined dimensions

### DIFF
--- a/Classes/EventListener/BeforeFileProcessing.php
+++ b/Classes/EventListener/BeforeFileProcessing.php
@@ -33,6 +33,11 @@ class BeforeFileProcessing
 				($context->isBackend() && $this->configuration['common']['backend']) ||
 				($context->isFrontend() && $this->configuration['common']['frontend'])
 			) &&
+			(
+				$file->getTask()->getSourceFile()->exists() &&
+				$file->getTask()->getSourceFile()->getProperty('width') &&
+				$file->getTask()->getSourceFile()->getProperty('height')
+			) &&
 			$this->service?->hasConfiguration() &&
 			$this->service?->canProcessTask($file->getTask())
 		) {

--- a/Classes/ImageService/BunnyImageService.php
+++ b/Classes/ImageService/BunnyImageService.php
@@ -41,7 +41,6 @@ class BunnyImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/CloudImageImageService.php
+++ b/Classes/ImageService/CloudImageImageService.php
@@ -46,7 +46,6 @@ class CloudImageImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/CloudflareImageService.php
+++ b/Classes/ImageService/CloudflareImageService.php
@@ -36,7 +36,6 @@ class CloudflareImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/CloudinaryImageService.php
+++ b/Classes/ImageService/CloudinaryImageService.php
@@ -52,7 +52,6 @@ class CloudinaryImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/GumletImageService.php
+++ b/Classes/ImageService/GumletImageService.php
@@ -42,7 +42,6 @@ class GumletImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/ImageKitImageService.php
+++ b/Classes/ImageService/ImageKitImageService.php
@@ -41,7 +41,6 @@ class ImageKitImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/ImagorImageService.php
+++ b/Classes/ImageService/ImagorImageService.php
@@ -53,7 +53,6 @@ class ImagorImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			($task->getSourceFile()->getStorage()?->isPublic()) &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/ImgProxyImageService.php
+++ b/Classes/ImageService/ImgProxyImageService.php
@@ -60,7 +60,6 @@ class ImgProxyImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/ImgixImageService.php
+++ b/Classes/ImageService/ImgixImageService.php
@@ -41,7 +41,6 @@ class ImgixImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/OptimoleImageService.php
+++ b/Classes/ImageService/OptimoleImageService.php
@@ -38,7 +38,6 @@ class OptimoleImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/SirvImageService.php
+++ b/Classes/ImageService/SirvImageService.php
@@ -35,7 +35,6 @@ class SirvImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			$task->getSourceFile()->getStorage()?->isPublic() &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/ImageService/ThumborImageService.php
+++ b/Classes/ImageService/ThumborImageService.php
@@ -53,7 +53,6 @@ class ThumborImageService extends ImageServiceAbstract
 	public function canProcessTask(TaskInterface $task): bool
 	{
 		return
-			$task->getSourceFile()->exists() &&
 			($task->getSourceFile()->getStorage()?->isPublic()) &&
 			in_array($task->getName(), ['Preview', 'CropScaleMask'], true) &&
 			in_array($task->getSourceFile()->getMimeType(), [

--- a/Classes/Processor/MediaProcessor.php
+++ b/Classes/Processor/MediaProcessor.php
@@ -34,6 +34,11 @@ class MediaProcessor implements ProcessorInterface
 				($context->isBackend() && $this->configuration['common']['backend']) ||
 				($context->isFrontend() && $this->configuration['common']['frontend'])
 			) &&
+			(
+				$task->getSourceFile()->exists() &&
+				$task->getSourceFile()->getProperty('width') &&
+				$task->getSourceFile()->getProperty('height')
+			) &&
 			$this->service?->hasConfiguration() &&
 			$this->service?->canProcessTask($task);
 	}


### PR DESCRIPTION
Skips processing for files which have no proper dimensions set. This means that processing will fall back to any other registered processing service which can handle this case; in most cases, it will most likely fall back to the local processing service.

Currently, this will affect processing of PDF files via the `imgproxy` integration, which wasn't working correctly anyway.