### PR TITLE
Prevent large amount of updates on sys_file_processedfile

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 	if ($service?->hasConfiguration()) {
 		$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['processors'][MediaProcessor::class] = [
 			'className' => MediaProcessor::class,
-			'before' => ['LocalImageProcessor', 'DeferredBackendImageProcessor'],
+			'before' => ['LocalImageProcessor', 'DeferredBackendImageProcessor', 'OnlineMediaPreviewProcessor'],
 		];
 	}
 })();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,4 +1,7 @@
 CREATE TABLE sys_file_processedfile (
 	`integration` VARCHAR(32),
-	`integration_checksum` VARCHAR(40)
+	`integration_checksum` VARCHAR(40),
+
+	key `integration` ( `integration` ),
+        key `integration_checksum` ( `integration_checksum` )
 );


### PR DESCRIPTION
Hey, 
we recently recognized that our mysql binlog was getting very large with the latest version in TYPO3 v13. 

That's why we added a check if the calculated checksum already exists and if yes, we don't update the according database entry (the reason why i check this in database and not in the _processed_ files is, that we are currently trying to get rid of all the files in _processed_). 
Maybe it's something you want to add? Or do you have any suggestions for improvement? 

Thanks in advance, 
David 