### PR TITLE
fix: correct type hint in OnlineMediaUtility::getPreviewImage

### DIFF
--- a/Classes/Builder/BunnyUrlSource.php
+++ b/Classes/Builder/BunnyUrlSource.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class BunnyUrlSource implements SourceInterface
 {
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/CloudImageUrlSource.php
+++ b/Classes/Builder/CloudImageUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class CloudImageUrlSource implements SourceInterface
 {
@@ -14,7 +14,7 @@ class CloudImageUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/CloudflareUrlSource.php
+++ b/Classes/Builder/CloudflareUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class CloudflareUrlSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class CloudflareUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/CloudinaryFetchSource.php
+++ b/Classes/Builder/CloudinaryFetchSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class CloudinaryFetchSource implements SourceInterface
 {
@@ -21,7 +21,7 @@ class CloudinaryFetchSource implements SourceInterface
 		return self::IDENTIFIER;
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/CloudinaryUploadSource.php
+++ b/Classes/Builder/CloudinaryUploadSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class CloudinaryUploadSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class CloudinaryUploadSource implements SourceInterface
 		return self::IDENTIFIER;
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getIdentifier();
 

--- a/Classes/Builder/GumletFolderSource.php
+++ b/Classes/Builder/GumletFolderSource.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class GumletFolderSource implements SourceInterface
 {
 	public const IDENTIFIER = 'folder';
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/GumletProxySource.php
+++ b/Classes/Builder/GumletProxySource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class GumletProxySource implements SourceInterface
 {
@@ -21,7 +21,7 @@ class GumletProxySource implements SourceInterface
 		return $this->host;
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/ImageKitUrlSource.php
+++ b/Classes/Builder/ImageKitUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImageKitUrlSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class ImageKitUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/ImagorFileSource.php
+++ b/Classes/Builder/ImagorFileSource.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImagorFileSource implements SourceInterface
 {
 	public const IDENTIFIER = 'file';
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getIdentifier();
 

--- a/Classes/Builder/ImagorUrlSource.php
+++ b/Classes/Builder/ImagorUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImagorUrlSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class ImagorUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/ImgLabProxySource.php
+++ b/Classes/Builder/ImgLabProxySource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImgLabProxySource implements SourceInterface
 {
@@ -20,7 +20,7 @@ class ImgLabProxySource implements SourceInterface
 		return $this->host;
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/ImgLabWebSource.php
+++ b/Classes/Builder/ImgLabWebSource.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImgLabWebSource implements SourceInterface
 {
 	public const IDENTIFIER = 'web';
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/ImgProxyFileSource.php
+++ b/Classes/Builder/ImgProxyFileSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImgProxyFileSource implements SourceInterface
 {
@@ -13,7 +13,7 @@ class ImgProxyFileSource implements SourceInterface
 
 	public const PROTOCOL = 'local://';
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getIdentifier();
 

--- a/Classes/Builder/ImgProxyUrlSource.php
+++ b/Classes/Builder/ImgProxyUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImgProxyUrlSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class ImgProxyUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/ImgixFolderSource.php
+++ b/Classes/Builder/ImgixFolderSource.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImgixFolderSource implements SourceInterface
 {
 	public const IDENTIFIER = 'folder';
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getIdentifier();
 

--- a/Classes/Builder/ImgixProxySource.php
+++ b/Classes/Builder/ImgixProxySource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ImgixProxySource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class ImgixProxySource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/OptimoleUrlSource.php
+++ b/Classes/Builder/OptimoleUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class OptimoleUrlSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class OptimoleUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Builder/SirvUrlSource.php
+++ b/Classes/Builder/SirvUrlSource.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class SirvUrlSource implements SourceInterface
 {
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		return $this->build($file);
 	}
 
-	private function build(FileInterface $source): string
+	private function build(File $source): string
 	{
 		$path = parse_url($source->getPublicUrl(), PHP_URL_PATH);
 		$query = parse_url($source->getPublicUrl(), PHP_URL_QUERY) ?? '';

--- a/Classes/Builder/SourceInterface.php
+++ b/Classes/Builder/SourceInterface.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 interface SourceInterface
 {
-	public function getSource(FileInterface $file): string;
+	public function getSource(File $file): string;
 }

--- a/Classes/Builder/ThumborFileSource.php
+++ b/Classes/Builder/ThumborFileSource.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ThumborFileSource implements SourceInterface
 {
 	public const IDENTIFIER = 'file';
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getIdentifier();
 

--- a/Classes/Builder/ThumborUrlSource.php
+++ b/Classes/Builder/ThumborUrlSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SomehowDigital\Typo3\MediaProcessing\Builder;
 
 use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 
 class ThumborUrlSource implements SourceInterface
 {
@@ -16,7 +16,7 @@ class ThumborUrlSource implements SourceInterface
 	) {
 	}
 
-	public function getSource(FileInterface $file): string
+	public function getSource(File $file): string
 	{
 		$url = OnlineMediaUtility::getPreviewImage($file) ?? $file->getPublicUrl();
 

--- a/Classes/Utility/OnlineMediaUtility.php
+++ b/Classes/Utility/OnlineMediaUtility.php
@@ -2,13 +2,13 @@
 
 namespace SomehowDigital\Typo3\MediaProcessing\Utility;
 
-use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class OnlineMediaUtility
 {
-	public static function getPreviewImage(FileInterface $file): ?string
+	public static function getPreviewImage(File $file): ?string
 	{
 		$helper = GeneralUtility::makeInstance(OnlineMediaHelperRegistry::class)->getOnlineMediaHelper($file);
 		$image = $helper ? $helper->getPreviewImage($file) : null;


### PR DESCRIPTION
Replaces FileInterface with File to match what the method actually expects, and updates all cascading references across the codebase.

https://github.com/TYPO3/typo3/blob/v13.4.32/typo3/sysext/core/Classes/Resource/OnlineMedia/Helpers/OnlineMediaHelperRegistry.php#L41

https://github.com/TYPO3/typo3/blob/v13.4.32/typo3/sysext/core/Classes/Resource/OnlineMedia/Helpers/OnlineMediaHelperInterface.php#L66