### PR TITLE
Test/unit and functional baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+ tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            php:
+                - '8.2'
+                - '8.3'
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up PHP version ${{ matrix.php }}
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            tools: composer:v2, php-cs-fixer
+
+        - name: Environment Check
+          run: |
+            php --version
+            composer --version
+
+        - name: Validate composer.json and composer.lock
+          run: composer validate
+
+        - name: Install dependencies
+          uses: ramsey/composer-install@v2
+
+        - name: Info
+          run: composer info
+
+        - name: Run unit tests
+          run: ./vendor/bin/phpunit Tests/Unit
+
+        - name: Run functional tests
+          run: ./vendor/bin/phpunit Tests/Functional  --bootstrap Tests/FunctionalTestsBootstrap.php

--- a/Tests/Functional/Processing/ImgProxyProcessingTest.php
+++ b/Tests/Functional/Processing/ImgProxyProcessingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Functional\Processing;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class ImgProxyProcessingTest extends FunctionalTestCase
+{
+	protected array $coreExtensionsToLoad = ['core', 'fluid'];
+
+	protected array $testExtensionsToLoad = [
+		'typo3conf/ext/media_processing',
+	];
+
+	protected array $configurationToUseInTestInstance = [
+		'EXTENSIONS' => [
+			'media_processing' => [
+				'common' => [
+					'provider' => 'imgproxy',
+					'frontend' => true,
+					'storage' => false,
+				],
+				'provider' => [
+					'imgproxy' => [
+						'api_endpoint' => 'https://imgproxy.example.com',
+						'source_loader' => 'uri',
+						'source_uri' => null,
+						'signature' => true,
+						'signature_key' => 'b76233cf37418a',
+						'signature_salt' => 'c89344df48529b',
+						'signature_size' => null,
+						'encryption' => false,
+						'encryption_key' => null,
+					],
+				],
+			],
+		],
+	];
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->setUpStorage();
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['TYPO3_REQUEST']);
+		parent::tearDown();
+	}
+
+	private function setUpStorage(): void
+	{
+		$storageRepository = GeneralUtility::makeInstance(StorageRepository::class);
+		$defaultStorage = $storageRepository->getDefaultStorage();
+
+		$fixturePath = $defaultStorage->getPublicUrl($defaultStorage->getRootLevelFolder()) . 'test-image.jpg';
+		if (!file_exists($fixturePath)) {
+			$imageContent = file_get_contents('https://picsum.photos/200/300');
+			file_put_contents($this->instancePath . '/' . $fixturePath, $imageContent);
+		}
+	}
+
+	#[Test]
+	public function imageProcessingAppliesImgProxyUrlTemplateAndSignature(): void
+	{
+		$GLOBALS['TYPO3_REQUEST'] = (new ServerRequest(new Uri('http://typo3')))
+			->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
+
+		$resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
+
+		// Retrieve our file reference from the sandbox FAL system
+		$file = $resourceFactory->getFileObjectFromCombinedIdentifier('1:/test-image.jpg');
+
+		// Target processing instructions (e.g. crop/resize via Fluid or Controller)
+		$processingInstructions = [
+			'width' => '100',
+			'height' => '100c',
+			'crop' => null,
+		];
+
+		$processedFile = $file->process(ProcessedFile::CONTEXT_IMAGECROPSCALEMASK, $processingInstructions);
+
+		$this->assertTrue($processedFile->isProcessed());
+
+		$publicUrl = $processedFile->getPublicUrl();
+
+		$this->assertStringStartsWith('https://imgproxy.example.com', $publicUrl);
+		$this->assertStringContainsString('/w:100/h:100/', $publicUrl);
+	}
+}

--- a/Tests/FunctionalTests.xml
+++ b/Tests/FunctionalTests.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+    Functional test suite setup for gsb_newsletter extension.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Functional\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+         backupGlobals="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="FunctionalTestsBootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         cacheResult="false"
+         colors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         requireCoverageMetadata="true"
+>
+    <testsuites>
+        <testsuite name="Functional">
+            <directory>./Functional/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">../Classes</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">../Classes/Tests</directory>
+            <directory suffix=".php">../Tests</directory>
+        </exclude>
+    </source>
+
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>
+

--- a/Tests/FunctionalTestsBootstrap.php
+++ b/Tests/FunctionalTestsBootstrap.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a functional test phpunit bootstrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a FunctionalTests.xml file.
+ *
+ * This file is defined in FunctionalTests.xml and called by phpunit
+ * before instantiating the test suites.
+ */
+(static function () {
+	// Set default database configuration for tests if not already set
+	if (!getenv('typo3DatabaseDriver')) {
+		putenv('typo3DatabaseDriver=pdo_sqlite');
+	}
+	if (!getenv('typo3DatabaseName')) {
+		putenv('typo3DatabaseName=test');
+	}
+
+	$testbase = new \TYPO3\TestingFramework\Core\Testbase();
+	$testbase->defineOriginalRootPath();
+	$testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
+	$testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+})();

--- a/Tests/Unit/Builder/BunnyBuilderTest.php
+++ b/Tests/Unit/Builder/BunnyBuilderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\BunnyBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class BunnyBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://myzone.b-cdn.net';
+
+	#[Test]
+	public function gettersAndSettersPropertiesCanBeSetAndRetrieved(): void
+	{
+		$builder = new BunnyBuilder(self::BASE_URL, 'my-secret-key');
+
+		$this->assertSame(self::BASE_URL, $builder->getEndpoint());
+		$this->assertSame('my-secret-key', $builder->getKey());
+
+		$this->assertSame($builder, $builder->setSource('images/photo.jpg'));
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+
+		$this->assertSame($builder, $builder->setWidth(800));
+		$this->assertSame(800, $builder->getWidth());
+
+		$this->assertSame($builder, $builder->setHeight(600));
+		$this->assertSame(600, $builder->getHeight());
+
+		$this->assertSame($builder, $builder->setCrop(100, 200, 10, 20));
+		$this->assertSame([100, 200, 10, 20], $builder->getCrop());
+	}
+
+	#[Test]
+	public function setCropHandlesNegativeValuesByEnforcingZero(): void
+	{
+		$builder = new BunnyBuilder(self::BASE_URL, null);
+		$builder->setCrop(-50, 100, -10, 0);
+
+		$this->assertSame([0, 100, 0, 0], $builder->getCrop());
+	}
+
+	#[Test]
+	public function buildReturnsUrlWithoutTokenWhenKeyIsMissing(): void
+	{
+		$builder = new BunnyBuilder('https://myzone.b-cdn.net/', null);
+
+		$builder->setSource('/images/banner.jpg')
+			->setWidth(1200)
+			->setHeight(630)
+			->setCrop(1200, 630, 0, 0);
+
+		$expectedUrl = 'https://myzone.b-cdn.net/images%2Fbanner.jpg?crop=1200%2C630%2C0%2C0&height=630&width=1200';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildReturnsSignedUrlWhenKeyIsProvided(): void
+	{
+		$key = 'super-secret-bunny-key';
+		$builder = new BunnyBuilder(self::BASE_URL, $key);
+
+		$builder->setSource('images/avatar.png')
+			->setWidth(200);
+
+		$expectedExpiration = time() + BunnyBuilder::SIGNATURE_EXPIRATION;
+		$url = $builder->build();
+
+		$this->assertStringStartsWith('https://myzone.b-cdn.net/images%2Favatar.png?width=200&token=', $url);
+		$this->assertStringContainsString('&expires=' . $expectedExpiration, $url);
+
+		$data = implode('', [
+			$key,
+			'/images%2Favatar.png',
+			$expectedExpiration,
+			'width=200',
+		]);
+		$hash = hash('sha256', $data, true);
+		$expectedSignature = str_replace('=', '', strtr(base64_encode($hash), '+/', '-_'));
+
+		$this->assertStringContainsString('token=' . $expectedSignature, $url);
+	}
+}

--- a/Tests/Unit/Builder/BunnyUrlSourceTest.php
+++ b/Tests/Unit/Builder/BunnyUrlSourceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\BunnyUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class BunnyUrlSourceTest extends UnitTestCase
+{
+	private BunnyUrlSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new BunnyUrlSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	protected function tearDown(): void
+	{
+		// Purges mock singletons injected into GeneralUtility to keep tests isolated
+		GeneralUtility::purgeInstances();
+		parent::tearDown();
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility securely returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/youtube-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		// Path should extract from /typo3temp and have its leading slash trimmed via build()
+		$this->assertSame('typo3temp/assets/online_media/youtube-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/image.png',
+			'fileadmin/assets/image.png',
+		];
+
+		yield 'domain structure is discarded' => [
+			'https://storage.bunnycdn.com/subfolder/pic.jpg',
+			'subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?token=abc&expiry=123',
+			'banner.jpg?token=abc&expiry=123',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/avatar.gif?',
+			'images/avatar.gif',
+		];
+	}
+}

--- a/Tests/Unit/Builder/CloudImageBuilderTest.php
+++ b/Tests/Unit/Builder/CloudImageBuilderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudImageBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudImageBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://demo.cloudimage.io';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new CloudImageBuilder(self::BASE_URL, 'secret_key');
+
+		$builder->setSource('images/banner.jpg')
+			->setFunction('crop')
+			->setWidth(1200)
+			->setHeight(630)
+			->setCrop(100, 150, 10, 20);
+
+		$this->assertSame('images/banner.jpg', $builder->getSource());
+		$this->assertSame('crop', $builder->getFunction());
+		$this->assertSame(1200, $builder->getWidth());
+		$this->assertSame(630, $builder->getHeight());
+		$this->assertSame([100, 150, 10, 20], $builder->getCrop());
+	}
+
+	#[Test]
+	public function buildGeneratesUnsignedUrlWhenKeyIsNull(): void
+	{
+		$builder = new CloudImageBuilder(self::BASE_URL, null);
+		$builder->setSource('folder/image.png')
+			->setWidth(300)
+			->setHeight(200);
+
+		$expectedUrl = 'https://demo.cloudimage.io/folder%2Fimage.png?w=300&h=200';
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	#[DataProvider('cloudImageTransformationsDataProvider')]
+	public function buildGeneratesCorrectlyOrderedAndSignedUrls(
+		?string $function,
+		?int $width,
+		?int $height,
+		?array $crop,
+		string $expectedPathAndQuery,
+		string $expectedSignature
+	): void {
+		$builder = new CloudImageBuilder('https://test.cloudimage.io', 'test-signing-key');
+		$builder->setSource('gallery/photo.png');
+
+		if ($function !== null) {
+			$builder->setFunction($function);
+		}
+		if ($width !== null) {
+			$builder->setWidth($width);
+		}
+		if ($height !== null) {
+			$builder->setHeight($height);
+		}
+		if ($crop !== null) {
+			$builder->setCrop(...$crop);
+		}
+
+		$expectedUrl = sprintf(
+			'https://test.cloudimage.io/%s&ci_sign=%s',
+			$expectedPathAndQuery,
+			$expectedSignature
+		);
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function cloudImageTransformationsDataProvider(): \Generator
+	{
+		yield 'basic scaling parameters' => [
+			'bound',
+			800,
+			600,
+			null,
+			'gallery%2Fphoto.png?func=bound&w=800&h=600',
+			'e7b24f9223318a4c89a1cfefdd46b949110ec3ad', // Pre-calculated sha1 hash
+		];
+
+		yield 'crop options mapping via box bounding calculations' => [
+			null,
+			null,
+			null,
+			[100, 150, 10, 20], // width, height, horizontal (x offset), vertical (y offset)
+			'gallery%2Fphoto.png?tl_px=100,150&br_px=110,170', // tl_px = [w, h], br_px = [w + x, h + y]
+			'94e55ea7c405abd591bbc465714d91c2df0ddb12',
+		];
+
+		yield 'all options active synchronously' => [
+			'crop',
+			400,
+			400,
+			[50, 50, 5, 5],
+			'gallery%2Fphoto.png?func=crop&w=400&h=400&tl_px=50,50&br_px=55,55',
+			'c318669e2a22f621cb3a482800a97e0fb6c3874c',
+		];
+	}
+}

--- a/Tests/Unit/Builder/CloudImageUrlSourceTest.php
+++ b/Tests/Unit/Builder/CloudImageUrlSourceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudImageUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudImageUrlSourceTest extends UnitTestCase
+{
+	private CloudImageUrlSource $subject;
+	private string $testHost = 'https://demo.cloudimage.io';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new CloudImageUrlSource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility securely returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://demo.cloudimage.io/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/dailymotion-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		// Path should extract from /typo3temp and have its leading slash trimmed when prepended to the host
+		$this->assertSame('https://demo.cloudimage.io/typo3temp/assets/online_media/dailymotion-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://demo.cloudimage.io/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://demo.cloudimage.io/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?width=100&quality=high',
+			'https://demo.cloudimage.io/banner.jpg?width=100&quality=high',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://demo.cloudimage.io/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/CloudflareBuilderTest.php
+++ b/Tests/Unit/Builder/CloudflareBuilderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudflareBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudflareBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://example.com/cdn-cgi/image';
+
+	#[Test]
+	public function gettersAndSettersPropertiesCanBeSetAndRetrieved(): void
+	{
+		$builder = new CloudflareBuilder(self::BASE_URL);
+
+		$this->assertSame($builder, $builder->setSource('images/photo.jpg'));
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+
+		$this->assertSame($builder, $builder->setFit('contain'));
+		$this->assertSame('contain', $builder->getFit());
+
+		$this->assertSame($builder, $builder->setWidth(800));
+		$this->assertSame(800, $builder->getWidth());
+
+		$this->assertSame($builder, $builder->setHeight(600));
+		$this->assertSame(600, $builder->getHeight());
+
+		$this->assertSame($builder, $builder->setTrim(10, 20, 30, 40));
+		$this->assertSame([10, 20, 30, 40], $builder->getTrim());
+
+		$this->assertSame($builder, $builder->setGravity(0.5, 0.75));
+		$this->assertSame([0.5, 0.75], $builder->getGravity());
+	}
+
+	#[Test]
+	public function setTrimHandlesNegativeValuesByEnforcingZero(): void
+	{
+		$builder = new CloudflareBuilder(self::BASE_URL);
+		$builder->setTrim(-10, 5, -20, 0);
+
+		$this->assertSame([0, 5, 0, 0], $builder->getTrim());
+	}
+
+	#[Test]
+	public function buildReturnsFormattedUrlWithOptionsAndSource(): void
+	{
+		$builder = new CloudflareBuilder('https://example.com/cdn-cgi/image/');
+
+		$builder->setSource('/uploads/hero.png')
+			->setFit('cover')
+			->setWidth(1920)
+			->setHeight(1080)
+			->setTrim(5, 10, 5, 10)
+			->setGravity(0.5, 0.5);
+
+		// Expects Cloudflare format:
+		// - Options comma-separated (fit=cover,width=1920,height=1080,trim=5;10;5;10,gravity=0.5x0.5)
+		// - Trim values separated by semicolons
+		// - Gravity values separated by 'x'
+		// - A trailing slash between options block and the URL-encoded source
+		$expectedUrl = 'https://example.com/cdn-cgi/image/fit=cover,width=1920,height=1080,trim=5;10;5;10,gravity=0.5x0.5/uploads%2Fhero.png';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildOmitsEmptyParameters(): void
+	{
+		$builder = new CloudflareBuilder(self::BASE_URL);
+
+		$builder->setSource('images/minimal.jpg')
+			->setWidth(300);
+
+		$expectedUrl = 'https://example.com/cdn-cgi/image/width=300/images%2Fminimal.jpg';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+}

--- a/Tests/Unit/Builder/CloudflareUrlSourceTest.php
+++ b/Tests/Unit/Builder/CloudflareUrlSourceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudflareUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudflareUrlSourceTest extends UnitTestCase
+{
+	private CloudflareUrlSource $subject;
+	private string $testHost = 'https://images.my-cloudflare-domain.com';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new CloudflareUrlSource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility securely returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://images.my-cloudflare-domain.com/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/vimeo-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		// Path should extract from /typo3temp and have its leading slash trimmed when prepended to the host
+		$this->assertSame('https://images.my-cloudflare-domain.com/typo3temp/assets/online_media/vimeo-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://images.my-cloudflare-domain.com/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://images.my-cloudflare-domain.com/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?width=100&quality=high',
+			'https://images.my-cloudflare-domain.com/banner.jpg?width=100&quality=high',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://images.my-cloudflare-domain.com/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/CloudinaryBuilderTest.php
+++ b/Tests/Unit/Builder/CloudinaryBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudinaryBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudinaryFetchSource;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudinaryBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://api.cloudinary.com/v1_1/demo';
+
+	#[Test]
+	public function gettersAndSettersPropertiesCanBeSetAndRetrieved(): void
+	{
+		$deliveryStub = $this->createStub(SourceInterface::class);
+		$builder = new CloudinaryBuilder(self::BASE_URL, $deliveryStub, 'secret-key', 'sha256');
+
+		$this->assertSame(self::BASE_URL, $builder->getEndpoint());
+		$this->assertSame($deliveryStub, $builder->getDelivery());
+
+		$this->assertSame($builder, $builder->setSource('images/photo.jpg'));
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+
+		$this->assertSame($builder, $builder->setMode('fill'));
+		$this->assertSame('fill', $builder->getMode());
+
+		$this->assertSame($builder, $builder->setWidth(800));
+		$this->assertSame(800, $builder->getWidth());
+
+		$this->assertSame($builder, $builder->setHeight(600));
+		$this->assertSame(600, $builder->getHeight());
+
+		$this->assertSame($builder, $builder->setCrop(10, 20, 300, 400));
+		$this->assertSame([10, 20, 300, 400], $builder->getCrop());
+	}
+
+	#[Test]
+	public function buildReturnsUnsignedUrlWhenKeyIsNull(): void
+	{
+		$deliveryMock = $this->createMock(CloudinaryFetchSource::class);
+		$deliveryMock
+			->expects($this->once())
+			->method('getIdentifier')
+			->willReturn('upload');
+
+		$builder = new CloudinaryBuilder('https://api.cloudinary.com/v1_1/demo/', $deliveryMock, null, null);
+
+		$builder->setSource('/products/shoes.png')
+			->setMode('limit')
+			->setWidth(400)
+			->setHeight(300);
+
+		// Expected format: %endpoint%/image/%delivery%/%options%/%source%
+		$expectedUrl = 'https://api.cloudinary.com/v1_1/demo/image/upload/c_limit,w_400,h_300/products%2Fshoes.png';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildReturnsUrlWithCombinedCropAndModeOptions(): void
+	{
+		$deliveryMock = $this->createMock(CloudinaryFetchSource::class);
+		$deliveryMock
+			->expects($this->once())
+			->method('getIdentifier')
+			->willReturn('authenticated');
+
+		$builder = new CloudinaryBuilder(self::BASE_URL, $deliveryMock, null, null);
+
+		$builder->setSource('gallery/landscape.jpg')
+			->setCrop(50, 50, 800, 600)
+			->setMode('thumb')
+			->setWidth(200)
+			->setHeight(150);
+
+		// Expects crop configurations first, then mode parameters separated by slashes
+		$expectedUrl = 'https://api.cloudinary.com/v1_1/demo/image/authenticated/c_crop,x_50,y_50,w_800,h_600/c_thumb,w_200,h_150/gallery%2Flandscape.jpg';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildReturnsSignedUrlWhenKeyAndAlgorithmAreProvided(): void
+	{
+		$deliveryMock = $this->createMock(CloudinaryFetchSource::class);
+		$deliveryMock
+			->expects($this->once())
+			->method('getIdentifier')
+			->willReturn('upload');
+
+		$key = 'my-cloudinary-key';
+		$algorithm = 'sha256';
+		$builder = new CloudinaryBuilder(self::BASE_URL, $deliveryMock, $key, $algorithm);
+
+		$builder->setSource('avatar.jpg')
+			->setMode('scale')
+			->setWidth(100);
+
+		$url = $builder->build();
+
+		// Programmatically recreate internal signature verification step
+		$expectedPath = 'c_scale,w_100/avatar.jpg';
+		$hash = hash($algorithm, $expectedPath . $key, true);
+		$digest = rtrim(strtr(base64_encode($hash), '+/', '-_'), '=');
+		$expectedSignature = 's--' . mb_substr($digest, 0, 8) . '--';
+
+		$expectedUrl = 'https://api.cloudinary.com/v1_1/demo/image/upload/' . $expectedSignature . '/' . $expectedPath;
+
+		$this->assertSame($expectedUrl, $url);
+	}
+}

--- a/Tests/Unit/Builder/CloudinaryFetchSourceTest.php
+++ b/Tests/Unit/Builder/CloudinaryFetchSourceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudinaryFetchSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudinaryFetchSourceTest extends UnitTestCase
+{
+	private CloudinaryFetchSource $subject;
+	private string $testHost = 'https://res.cloudinary.com/demo';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new CloudinaryFetchSource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getIdentifierReturnsExpectedConstant(): void
+	{
+		$this->assertSame('fetch', $this->subject->getIdentifier());
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility securely returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://res.cloudinary.com/demo/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/cloudinary-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		// Path should extract from /typo3temp and have its leading slash trimmed when prepended to the host
+		$this->assertSame('https://res.cloudinary.com/demo/typo3temp/assets/online_media/cloudinary-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://res.cloudinary.com/demo/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://res.cloudinary.com/demo/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?width=100&quality=high',
+			'https://res.cloudinary.com/demo/banner.jpg?width=100&quality=high',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://res.cloudinary.com/demo/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/GumletBuilderTest.php
+++ b/Tests/Unit/Builder/GumletBuilderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\GumletBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class GumletBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://demo.gumlet.io';
+
+	#[Test]
+	public function gettersAndSettersPropertiesCanBeSetAndRetrieved(): void
+	{
+		$builder = new GumletBuilder(self::BASE_URL, 'secret-key');
+
+		$this->assertSame(self::BASE_URL, $builder->getEndpoint());
+		$this->assertSame('secret-key', $builder->getKey());
+
+		$this->assertSame($builder, $builder->setSource('images/photo.jpg'));
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+
+		$this->assertSame($builder, $builder->setWidth(800));
+		$this->assertSame(800, $builder->getWidth());
+
+		$this->assertSame($builder, $builder->setHeight(600));
+		$this->assertSame(600, $builder->getHeight());
+
+		// Note GumletBuilder rearranges parameters internally to [horizontal, vertical, width, height]
+		$this->assertSame($builder, $builder->setCrop(300, 200, 10, 20));
+		$this->assertSame([10, 20, 300, 200], $builder->getCrop());
+
+		$this->assertSame($builder, $builder->setGravity(0.3, 0.6));
+		$this->assertSame([0.3, 0.6], $builder->getGravity());
+	}
+
+	#[Test]
+	public function setCropHandlesNegativeValuesByEnforcingZero(): void
+	{
+		$builder = new GumletBuilder(self::BASE_URL, null);
+		$builder->setCrop(-300, 200, -10, 0);
+
+		$this->assertSame([0, 0, 0, 200], $builder->getCrop());
+	}
+
+	#[Test]
+	public function buildReturnsUrlWithExtractWhenCropIsSetWithoutGravity(): void
+	{
+		$builder = new GumletBuilder('https://demo.gumlet.io/', null);
+
+		$builder->setSource('/assets/cover.png')
+			->setCrop(800, 400, 50, 60)
+			->setWidth(400);
+
+		// Expect extract mapping: horizontal, vertical, width, height
+		$expectedUrl = 'https://demo.gumlet.io/assets/cover.png?extract=50,60,800,400&w=400';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildReturnsFocalPointParametersWhenGravityIsPresent(): void
+	{
+		$builder = new GumletBuilder(self::BASE_URL, null);
+
+		$builder->setSource('assets/cover.png')
+			->setCrop(800, 400, 50, 60) // This configuration should be ignored due to gravity overrides
+			->setGravity(0.25, 0.75)
+			->setHeight(300);
+
+		$expectedUrl = 'https://demo.gumlet.io/assets/cover.png?mode=crop&crop=focalpoint&fp-x=0.25&fp-y=0.75&h=300';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildReturnsSignedUrlWhenKeyIsProvided(): void
+	{
+		$key = 'my-gumlet-secure-token';
+		$builder = new GumletBuilder(self::BASE_URL, $key);
+
+		$builder->setSource('product.jpg')
+			->setWidth(500);
+
+		$url = $builder->build();
+
+		// Verify base signature layout structure
+		$this->assertStringStartsWith('https://demo.gumlet.io/product.jpg?w=500&s=', $url);
+
+		// Programmatically recalculate internal MD5 hashing step
+		$expectedPath = 'product.jpg?w=500';
+		$data = $key . '/' . $expectedPath;
+		$expectedSignature = base64_encode(hash('md5', $data, true));
+
+		$this->assertStringEndsWith('&s=' . $expectedSignature, $url);
+	}
+}

--- a/Tests/Unit/Builder/GumletFolderSourceTest.php
+++ b/Tests/Unit/Builder/GumletFolderSourceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\GumletFolderSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class GumletFolderSourceTest extends UnitTestCase
+{
+	private GumletFolderSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new GumletFolderSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	#[DataProvider('getSourceDataProvider')]
+	public function getSourceReturnsCorrectlyFormattedPath(?string $previewUrl, ?string $publicUrl, string $expected): void
+	{
+		$fileStub = $this->createStub(File::class);
+
+		if ($previewUrl === null) {
+			$fileStub
+				->method('getPublicUrl')
+				->willReturn($publicUrl);
+		}
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($this->createConfiguredStub(OnlineMediaHelperInterface::class, [
+				'getPreviewImage' => $previewUrl,
+			]));
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expected, $result);
+	}
+
+	public static function getSourceDataProvider(): \Generator
+	{
+		yield 'Online media preview URL with query' => [
+			'https://example.com/preview/image.jpg?foo=bar', // OnlineMediaUtility result
+			null,                                            // file->getPublicUrl() result
+			'preview/image.jpg?foo=bar',                      // Expected output
+		];
+
+		yield 'Fallback to local file public URL without query' => [
+			null,
+			'/fileadmin/user_upload/photo.jpg',
+			'fileadmin/user_upload/photo.jpg',
+		];
+
+		yield 'Fallback to local file public URL with query' => [
+			null,
+			'https://cdn.domain.local/assets/doc.pdf?v=123',
+			'assets/doc.pdf?v=123',
+		];
+	}
+}

--- a/Tests/Unit/Builder/GumletProxySourceTest.php
+++ b/Tests/Unit/Builder/GumletProxySourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\GumletProxySource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class GumletProxySourceTest extends UnitTestCase
+{
+	private GumletProxySource $subject;
+	private string $testHost = 'https://example.gumlet.io';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new GumletProxySource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	#[DataProvider('proxyUrlDataProvider')]
+	public function getSourceReturnsCorrectlyFormattedPath(?string $previewUrl, ?string $publicUrl, string $expected): void
+	{
+		$fileStub = $this->createStub(File::class);
+
+		if ($previewUrl === null) {
+			$fileStub
+				->method('getPublicUrl')
+				->willReturn($publicUrl);
+		}
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($this->createConfiguredStub(OnlineMediaHelperInterface::class, [
+				'getPreviewImage' => $previewUrl,
+			]));
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expected, $result);
+	}
+
+	public static function proxyUrlDataProvider(): \Iterator
+	{
+		yield 'Host with trailing slash, path with query' => [
+			'https://example.com/images/pic.jpg?w=800&h=600',       // Preview URL string
+			null,                                                    // Public URL string
+			'fetch/https%3A%2F%2Fexample.gumlet.io%2Fimages%2Fpic.jpg%3Fw%3D800%26h%3D600', // Expected
+		];
+
+		yield 'Host without trailing slash, fallback to public URL' => [
+			null,
+			'/fileadmin/images/hero.png',
+			'fetch/https%3A%2F%2Fexample.gumlet.io%2Ffileadmin%2Fimages%2Fhero.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImageKitBuilderTest.php
+++ b/Tests/Unit/Builder/ImageKitBuilderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImageKitBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImageKitBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://ik.imagekit.io/demo';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new ImageKitBuilder(self::BASE_URL, 'secret_key');
+
+		$builder->setSource('images/photo.jpg')
+			->setMode('maintain')
+			->setWidth(800)
+			->setHeight(600)
+			->setCrop(100, 200, 10, 20);
+
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+		$this->assertSame('maintain', $builder->getMode());
+		$this->assertSame(800, $builder->getWidth());
+		$this->assertSame(600, $builder->getHeight());
+		$this->assertSame([100, 200, 10, 20], $builder->getCrop());
+	}
+
+	#[Test]
+	#[DataProvider('transformationDataProvider')]
+	public function buildGeneratesCorrectUrlStructureWithoutSignature(
+		string $source,
+		?string $mode,
+		?int $width,
+		?int $height,
+		?array $crop,
+		string $expectedPath
+	): void {
+		// Instantiate without a key to test pure path transformation logic
+		$builder = new ImageKitBuilder(self::BASE_URL, null);
+		$builder->setSource($source);
+
+		if ($mode !== null) {
+			$builder->setMode($mode);
+		}
+		if ($width !== null) {
+			$builder->setWidth($width);
+		}
+		if ($height !== null) {
+			$builder->setHeight($height);
+		}
+		if ($crop !== null) {
+			$builder->setCrop(...$crop);
+		}
+
+		$expectedUrl = 'https://ik.imagekit.io/demo/' . $expectedPath;
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildAppliesSecureSignatureWhenKeyIsProvided(): void
+	{
+		$builder = new ImageKitBuilder(self::BASE_URL, 'my_secret_key');
+		$builder->setSource('photo.jpg')
+			->setWidth(400);
+
+		$url = $builder->build();
+
+		// 1. Verify the base transformations are present
+		$this->assertStringStartsWith('https://ik.imagekit.io/demo/tr:cm-extract:w-400/photo.jpg', $url);
+
+		// 2. Since time() is dynamic, use regex to check parameters: ik-t (digits) and ik-s (sha1 hex string)
+		$this->assertMatchesRegularExpression('/[?&]ik-t=\d+/', $url);
+		$this->assertMatchesRegularExpression('/[?&]ik-s=[a-f0-9]{40}/', $url);
+	}
+
+	public static function transformationDataProvider(): \Generator
+	{
+		yield 'basic source path raw url encoded' => [
+			'folder/sub folder/image.jpg',
+			null,
+			null,
+			null,
+			null,
+			'tr:cm-extract/folder%2Fsub%20folder%2Fimage.jpg',
+		];
+
+		yield 'resize width and height with mode' => [
+			'image.jpg',
+			'pad',
+			300,
+			200,
+			null,
+			'tr:cm-extract:c-pad,w-300,h-200/image.jpg',
+		];
+
+		yield 'crop options mapped to extract options' => [
+			'image.jpg',
+			null,
+			null,
+			null,
+			[150, 150, 20, 10], // width, height, horizontal, vertical
+			'tr:cm-extract,w-150,h-150,x-20,y-10/image.jpg',
+		];
+
+		yield 'combined crop and resize properties' => [
+			'image.jpg',
+			'force',
+			100,
+			100,
+			[50, 50, 0, 0],
+			'tr:cm-extract,w-50,h-50:c-force,w-100,h-100/image.jpg',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImageKitUrlSourceTest.php
+++ b/Tests/Unit/Builder/ImageKitUrlSourceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImageKitUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImageKitUrlSourceTest extends UnitTestCase
+{
+	private ImageKitUrlSource $subject;
+	private string $testHost = 'https://ik.imagekit.io/mycompany';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImageKitUrlSource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://ik.imagekit.io/mycompany/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/youtube-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://ik.imagekit.io/mycompany/typo3temp/assets/online_media/youtube-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://ik.imagekit.io/mycompany/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://ik.imagekit.io/mycompany/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?tr=w-400,h-300',
+			'https://ik.imagekit.io/mycompany/banner.jpg?tr=w-400,h-300',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://ik.imagekit.io/mycompany/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImagorBuilderTest.php
+++ b/Tests/Unit/Builder/ImagorBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImagorBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImagorBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://imagor.example.com';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new ImagorBuilder(self::BASE_URL, 'secret', 'sha256', 40);
+
+		$builder->setSource('images/photo.jpg')
+			->setType('fit-in')
+			->setWidth(800)
+			->setHeight(600)
+			->setCrop(100, 200, 10, 20);
+
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+		$this->assertSame('fit-in', $builder->getType());
+		$this->assertSame(800, $builder->getWidth());
+		$this->assertSame(600, $builder->getHeight());
+		$this->assertSame([100, 200, 10, 20], $builder->getCrop());
+	}
+
+	#[Test]
+	public function buildReturnsUnsafePathWhenNoKeyIsProvided(): void
+	{
+		$builder = new ImagorBuilder(self::BASE_URL, null, 'sha256', 40);
+		$builder->setSource('my-image.jpg')
+			->setWidth(300)
+			->setHeight(200);
+
+		// Imagor falls back to /unsafe/ prefix when no signing key exists
+		$expectedUrl = 'https://imagor.example.com/unsafe/300x200/my-image.jpg';
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	#[DataProvider('imagorPathDataProvider')]
+	public function buildGeneratesCorrectPathStructureAndSignature(
+		?string $type,
+		?int $width,
+		?int $height,
+		?array $crop,
+		string $expectedPath,
+		string $expectedSignature
+	): void {
+		// Using fixed config strings to test deterministic signature outputs
+		$builder = new ImagorBuilder(self::BASE_URL, 'test-signing-key', 'sha256', 10);
+		$builder->setSource('folder/image.png');
+
+		if ($type !== null) {
+			$builder->setType($type);
+		}
+		if ($width !== null) {
+			$builder->setWidth($width);
+		}
+		if ($height !== null) {
+			$builder->setHeight($height);
+		}
+		if ($crop !== null) {
+			$builder->setCrop(...$crop);
+		}
+
+		$expectedUrl = sprintf('https://imagor.example.com/%s/%s', $expectedSignature, $expectedPath);
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function imagorPathDataProvider(): \Generator
+	{
+		yield 'only resizing coordinates' => [
+			null,
+			400,
+			300,
+			null,
+			'400x300/folder%2Fimage.png',
+			'2rUP_K50ul', // Pre-calculated URL-safe base64 hmac snippet
+		];
+
+		yield 'resizing with fit-in type strategy' => [
+			'fit-in',
+			800,
+			600,
+			null,
+			'fit-in/800x600/folder%2Fimage.png',
+			'o8vUdcLSyN',
+		];
+
+		yield 'crop mappings convert width/height into target box endpoints' => [
+			null,
+			null,
+			null,
+			[150, 100, 20, 30], // width, height, horizontal (x), vertical (y)
+			'20x30:170x130/folder%2Fimage.png', // x1xy1:x2xy2
+			'MQ5ciKFT6N',
+		];
+
+		yield 'full combined transformations pipeline' => [
+			'fit-in',
+			120,
+			120,
+			[50, 50, 10, 10],
+			'10x10:60x60/fit-in/120x120/folder%2Fimage.png',
+			'n3txtT_DGg',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImagorFileSourceTest.php
+++ b/Tests/Unit/Builder/ImagorFileSourceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImagorFileSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImagorFileSourceTest extends UnitTestCase
+{
+	private ImagorFileSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImagorFileSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToIdentifierWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn('/user_upload/images/photo.png');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('user_upload/images/photo.png', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn('/fallback-identifier.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/youtube-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('typo3temp/assets/online_media/youtube-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn($inputUrl);
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path if present' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?width=100&quality=high',
+			'banner.jpg?width=100&quality=high',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImagorUrlSourceTest.php
+++ b/Tests/Unit/Builder/ImagorUrlSourceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImagorUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImagorUrlSourceTest extends UnitTestCase
+{
+	private ImagorUrlSource $subject;
+	private string $testHost = 'https://imagor.my-domain.com';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImagorUrlSource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://imagor.my-domain.com/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/vimeo-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://imagor.my-domain.com/typo3temp/assets/online_media/vimeo-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://imagor.my-domain.com/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://imagor.my-domain.com/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?meta=true',
+			'https://imagor.my-domain.com/banner.jpg?meta=true',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://imagor.my-domain.com/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgLabBuilderTest.php
+++ b/Tests/Unit/Builder/ImgLabBuilderTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgLabBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgLabBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://assets.imglab-cdn.net';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new ImgLabBuilder(self::BASE_URL, 'a2V5', 'c2FsdA==');
+
+		$builder->setSource('uploads/banner.png')
+			->setMode('resize')
+			->setWidth(1200)
+			->setHeight(630)
+			->setRegion(5, 10, 500, 400);
+
+		$this->assertSame(self::BASE_URL, $builder->getEndpoint());
+		$this->assertSame('a2V5', $builder->getKey());
+		$this->assertSame('c2FsdA==', $builder->getSalt());
+		$this->assertSame('uploads/banner.png', $builder->getSource());
+		$this->assertSame('resize', $builder->getMode());
+		$this->assertSame(1200, $builder->getWidth());
+		$this->assertSame(630, $builder->getHeight());
+		$this->assertSame([5, 10, 500, 400], $builder->getRegion());
+	}
+
+	#[Test]
+	public function buildGeneratesUnsignedUrlWhenKeyIsNull(): void
+	{
+		$builder = new ImgLabBuilder(self::BASE_URL, null, null);
+		$builder->setSource('gallery/photo.png')
+			->setWidth(400)
+			->setHeight(300);
+
+		$expectedUrl = 'https://assets.imglab-cdn.net/gallery%2Fphoto.png?width=400&height=300';
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	#[DataProvider('imgLabTransformationsDataProvider')]
+	public function buildGeneratesCorrectlyOrderedAndSignedUrls(
+		?string $mode,
+		?int $width,
+		?int $height,
+		?array $region,
+		string $expectedPathAndQuery,
+		string $expectedSignature
+	): void {
+		// "key123" encoded in base64 is "a2V5MTIz"
+		// "salt123" encoded in base64 is "c2FsdDEyMw=="
+		$builder = new ImgLabBuilder(self::BASE_URL, 'a2V5MTIz', 'c2FsdDEyMw==');
+		$builder->setSource('products/item.jpg');
+
+		if ($mode !== null) {
+			$builder->setMode($mode);
+		}
+		if ($width !== null) {
+			$builder->setWidth($width);
+		}
+		if ($height !== null) {
+			$builder->setHeight($height);
+		}
+		if ($region !== null) {
+			$builder->setRegion(...$region);
+		}
+
+		$expectedUrl = sprintf(
+			'https://assets.imglab-cdn.net/%s&signature=%s',
+			$expectedPathAndQuery,
+			$expectedSignature
+		);
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function imgLabTransformationsDataProvider(): \Generator
+	{
+		yield 'basic sizing modifiers match standard structure' => [
+			'crop',
+			800,
+			600,
+			null,
+			'products%2Fitem.jpg?mode=crop&width=800&height=600',
+			'WcMBQ46QysHYRdaEhzQ7bCqUSH2vrbQC9XXY5OQLAKE', // Pre-calculated URL-safe base64 hmac snippet
+		];
+
+		yield 'region values compiled cleanly to string array sequence' => [
+			null,
+			null,
+			null,
+			[0, 50, 200, 200], // horizontal, vertical, width, height
+			'products%2Fitem.jpg?region=0,50,200,200',
+			'xpIlhoR-3e1m0H3B-k5Yj94KEt-8ScmNL3Gqg6VtGOg',
+		];
+
+		yield 'all processing constraints merged simultaneously' => [
+			'force',
+			300,
+			300,
+			[10, 10, 100, 100],
+			'products%2Fitem.jpg?mode=force&width=300&height=300&region=10,10,100,100',
+			'ouWJdAbH-N83HF6YenBq7Nr2eKffc-WZyHXrl4SftSQ',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgLabProxySourceTest.php
+++ b/Tests/Unit/Builder/ImgLabProxySourceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgLabProxySource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgLabProxySourceTest extends UnitTestCase
+{
+	private ImgLabProxySource $subject;
+	private string $testHost = 'https://assets.imglab-cdn.net/v1';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImgLabProxySource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getHostReturnsConfiguredHost(): void
+	{
+		$this->assertSame($this->testHost, $this->subject->getHost());
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://assets.imglab-cdn.net/v1/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/vimeo-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://assets.imglab-cdn.net/v1/typo3temp/assets/online_media/vimeo-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://assets.imglab-cdn.net/v1/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://assets.imglab-cdn.net/v1/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?dpr=2&width=500',
+			'https://assets.imglab-cdn.net/v1/banner.jpg?dpr=2&width=500',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://assets.imglab-cdn.net/v1/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgLabWebSourceTest.php
+++ b/Tests/Unit/Builder/ImgLabWebSourceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgLabWebSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgLabWebSourceTest extends UnitTestCase
+{
+	private ImgLabWebSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImgLabWebSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/vimeo-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('typo3temp/assets/online_media/vimeo-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?width=640&format=webp',
+			'banner.jpg?width=640&format=webp',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgProxyBuilderTest.php
+++ b/Tests/Unit/Builder/ImgProxyBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgProxyBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgProxyBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'http://localhost:8080';
+
+	#[Test]
+	public function gettersAndSettersPropertiesCanBeSetAndRetrieved(): void
+	{
+		$builder = new ImgProxyBuilder(self::BASE_URL, null, null, null, null);
+
+		$this->assertSame($builder, $builder->setSource('images/photo.jpg'));
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+
+		$this->assertSame($builder, $builder->setType('png'));
+		$this->assertSame('png', $builder->getType());
+
+		$this->assertSame($builder, $builder->setGravity(ImgProxyBuilder::GRAVITY_CENTER, 0.5, 0.5));
+		$this->assertSame([ImgProxyBuilder::GRAVITY_CENTER, 0.5, 0.5], $builder->getGravity());
+
+		$this->assertSame($builder, $builder->setWidth(800));
+		$this->assertSame(800, $builder->getWidth());
+
+		$this->assertSame($builder, $builder->setMinWidth(400));
+		$this->assertSame(400, $builder->getMinWidth());
+
+		$this->assertSame($builder, $builder->setHeight(600));
+		$this->assertSame(600, $builder->getHeight());
+
+		$this->assertSame($builder, $builder->setMinHeight(300));
+		$this->assertSame(300, $builder->getMinHeight());
+
+		$this->assertSame($builder, $builder->setCrop(100, 100, [ImgProxyBuilder::GRAVITY_TOP]));
+		$this->assertSame([100, 100, ImgProxyBuilder::GRAVITY_TOP], $builder->getCrop());
+
+		$this->assertSame($builder, $builder->setDevicePixelRatio(2.0));
+		$this->assertSame(2.0, $builder->getDevicePixelRatio());
+
+		$this->assertSame($builder, $builder->setHash('cachebuster123'));
+		$this->assertSame('cachebuster123', $builder->getHash());
+	}
+
+	#[Test]
+	public function buildReturnsInsecureUrlWhenSignatureCredentialsAreMissing(): void
+	{
+		$builder = new ImgProxyBuilder('http://localhost:8080/', null, null, null, null);
+
+		$builder->setSource('images/banner.jpg')
+			->setWidth(1200)
+			->setHeight(630)
+			->setType('webp');
+
+		$expectedUrl = 'http://localhost:8080/insecure/rt:webp/w:1200/h:630/plain/images%2Fbanner.jpg';
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	public function buildReturnsSecureUrlWhenSignatureCredentialsArePassed(): void
+	{
+		// Example keys (Hex encoded)
+		$key = bin2hex('test-key-32-bytes-long-abcde12345');
+		$salt = bin2hex('test-salt-32-bytes-long-abcde1234');
+
+		$builder = new ImgProxyBuilder('https://imgproxy.example.com', $key, $salt, 32, null);
+
+		$builder->setSource('avatar.png')
+			->setWidth(200);
+
+		$url = $builder->build();
+
+		// Ensure the base structure is correct and it doesn't contain 'insecure'
+		$this->assertStringStartsWith('https://imgproxy.example.com/', $url);
+		$this->assertStringNotContainsString('insecure', $url);
+		$this->assertStringEndsWith('/w:200/plain/avatar.png', $url);
+	}
+
+	#[Test]
+	public function buildReturnsEncryptedSourceUrlWhenSecretIsProvided(): void
+	{
+		if (!extension_loaded('openssl')) {
+			$this->markTestSkipped('The openssl extension is not available.');
+		}
+
+		$secret = 'super-secret-encryption-key-1234';
+		$builder = new ImgProxyBuilder(self::BASE_URL, null, null, null, $secret);
+
+		$builder->setSource('private/photo.jpg');
+		$url = $builder->build();
+
+		$this->assertStringContainsString('/enc/', $url);
+		$this->assertStringNotContainsString('private%2Fphoto.jpg', $url);
+	}
+}

--- a/Tests/Unit/Builder/ImgProxyFileSourceTest.php
+++ b/Tests/Unit/Builder/ImgProxyFileSourceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgProxyFileSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgProxyFileSourceTest extends UnitTestCase
+{
+	private ImgProxyFileSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['onlineMediaHelpers'] = [];
+		$this->subject = new ImgProxyFileSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['onlineMediaHelpers']);
+
+		parent::tearDown();
+	}
+
+	#[Test]
+	public function getSourceReturnsLocalProtocolWithCleanedPathWhenFileIdentifierIsProvided(): void
+	{
+		$fileMock = $this->createMock(File::class);
+		$fileMock
+			->expects($this->once())
+			->method('getIdentifier')
+			->willReturn('/user_upload/images/pic.jpg');
+
+		$result = $this->subject->getSource($fileMock);
+
+		$this->assertSame('local:///user_upload/images/pic.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function getSourceCorrectlyParsesAndFormatsUrlsWithVariousStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileMock = $this->createMock(File::class);
+		$fileMock
+			->expects($this->once())
+			->method('getIdentifier')
+			->willReturn($inputUrl);
+
+		$result = $this->subject->getSource($fileMock);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/path/to/file.png',
+			'local:///path/to/file.png',
+		];
+
+		yield 'no leading slash' => [
+			'path/to/file.png',
+			'local:///path/to/file.png',
+		];
+
+		yield 'with query parameters' => [
+			'/path/to/file.png?v=123&size=large',
+			'local:///path/to/file.png?v=123&size=large',
+		];
+
+		yield 'full absolute url fallback' => [
+			'https://example.com/sys_file/processed/image.jpg?foo=bar',
+			'local:///sys_file/processed/image.jpg?foo=bar',
+		];
+
+		yield 'empty query string ignored' => [
+			'/path/to/file.png?',
+			'local:///path/to/file.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgProxyUrlSourceTest.php
+++ b/Tests/Unit/Builder/ImgProxyUrlSourceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgProxyUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgProxyUrlSourceTest extends UnitTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['onlineMediaHelpers'] = [];
+		$this->resetSingletonInstances = true;
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['onlineMediaHelpers']);
+
+		parent::tearDown();
+	}
+
+	#[Test]
+	public function getSourceReturnsUrlPrefixedWithHostWhenPublicUrlIsProvided(): void
+	{
+		$fileMock = $this->createMock(File::class);
+		$fileMock
+			->expects($this->once())
+			->method('getPublicUrl')
+			->willReturn('/fileadmin/user_upload/photo.jpg');
+
+		$source = new ImgProxyUrlSource('https://cdn.example.com');
+		$result = $source->getSource($fileMock);
+
+		$this->assertSame('https://cdn.example.com/fileadmin/user_upload/photo.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function getSourceCorrectlyTrimsAndFormatsUrlsWithVariousStructures(
+		string $host,
+		string $inputUrl,
+		string $expectedOutput
+	): void {
+		$fileMock = $this->createMock(File::class);
+		$fileMock
+			->expects($this->once())
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		$source = new ImgProxyUrlSource($host);
+		$result = $source->getSource($fileMock);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'trailing slash on host and leading slash on path are normalized' => [
+			'https://cdn.example.com/',
+			'/images/photo.jpg',
+			'https://cdn.example.com/images/photo.jpg',
+		];
+
+		yield 'no slashes on boundaries are normalized' => [
+			'https://cdn.example.com',
+			'images/photo.jpg',
+			'https://cdn.example.com/images/photo.jpg',
+		];
+
+		yield 'query parameters are preserved cleanly' => [
+			'https://cdn.example.com',
+			'/images/photo.jpg?token=abc123_456&width=auto',
+			'https://cdn.example.com/images/photo.jpg?token=abc123_456&width=auto',
+		];
+
+		yield 'full external absolute public url parses path out correctly' => [
+			'https://cdn.example.com',
+			'https://another-domain.com/assets/banner.png?v=2',
+			'https://cdn.example.com/assets/banner.png?v=2',
+		];
+
+		yield 'empty query symbol is ignored' => [
+			'https://cdn.example.com',
+			'/images/photo.jpg?',
+			'https://cdn.example.com/images/photo.jpg',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgixBuilderTest.php
+++ b/Tests/Unit/Builder/ImgixBuilderTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgixBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgixBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://my-source.imgix.net';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new ImgixBuilder(self::BASE_URL, 'my-secure-token');
+
+		$builder->setSource('uploads/avatar.png')
+			->setFit('crop')
+			->setWidth(640)
+			->setMaxWidth(1024)
+			->setHeight(480)
+			->setMaxHeight(768)
+			->setRect(10, 20, 300, 250);
+
+		$this->assertSame(self::BASE_URL, $builder->getEndpoint());
+		$this->assertSame('my-secure-token', $builder->getKey());
+		$this->assertSame('uploads/avatar.png', $builder->getSource());
+		$this->assertSame('crop', $builder->getFit());
+		$this->assertSame(640, $builder->getWidth());
+		$this->assertSame(1024, $builder->getMaxWidth());
+		$this->assertSame(480, $builder->getHeight());
+		$this->assertSame(768, $builder->getMaxHeight());
+		$this->assertSame([10, 20, 300, 250], $builder->getRect());
+	}
+
+	#[Test]
+	public function buildGeneratesUnsignedUrlWhenKeyIsNull(): void
+	{
+		$builder = new ImgixBuilder(self::BASE_URL, null);
+		$builder->setSource('images/pic.jpg')
+			->setWidth(200)
+			->setHeight(100);
+
+		// Parameters should be alphabetized via ksort: h=100 then w=200
+		$expectedUrl = 'https://my-source.imgix.net/images%2Fpic.jpg?h=100&w=200';
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	#[DataProvider('imgixTransformationsDataProvider')]
+	public function buildGeneratesCorrectlyOrderedAndSignedUrls(
+		?string $fit,
+		?int $w,
+		?int $maxW,
+		?int $h,
+		?int $maxH,
+		?array $rect,
+		string $expectedPathAndQuery,
+		string $expectedSignature
+	): void {
+		// Secure token combined with standard endpoints
+		$builder = new ImgixBuilder(self::BASE_URL, 'secure-signing-key');
+		$builder->setSource('portfolio/item 1.png');
+
+		if ($fit !== null) {
+			$builder->setFit($fit);
+		}
+		if ($w !== null) {
+			$builder->setWidth($w);
+		}
+		if ($maxW !== null) {
+			$builder->setMaxWidth($maxW);
+		}
+		if ($h !== null) {
+			$builder->setHeight($h);
+		}
+		if ($maxH !== null) {
+			$builder->setMaxHeight($maxH);
+		}
+		if ($rect !== null) {
+			$builder->setRect(...$rect);
+		}
+
+		$expectedUrl = sprintf(
+			'https://my-source.imgix.net/%s&s=%s',
+			$expectedPathAndQuery,
+			$expectedSignature
+		);
+
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function imgixTransformationsDataProvider(): \Generator
+	{
+		yield 'basic scaling parameters sorted alphabetically' => [
+			null,
+			800,
+			null,
+			600,
+			null,
+			null,
+			'portfolio%2Fitem%201.png?h=600&w=800',
+			'003ddb55c38d677cd5d91f589782423e', // Pre-calculated md5 signature
+		];
+
+		yield 'max limits and fitting rules applied together' => [
+			'clamp',
+			null,
+			1200,
+			null,
+			900,
+			null,
+			'portfolio%2Fitem%201.png?fit=clamp&max-h=900&max-w=1200',
+			'da933d05c3459d8fe95a9db97eb39b81',
+		];
+
+		yield 'rect crop values passed smoothly as comma array string' => [
+			null,
+			null,
+			null,
+			null,
+			null,
+			[50, 50, 400, 300], // horizontal, vertical, width, height
+			'portfolio%2Fitem%201.png?rect=50%2C50%2C400%2C300',
+			'989ca4921cc66f48a88e2debbb3e60a0',
+		];
+
+		yield 'everything combined ensures full ksort optimization' => [
+			'face',
+			400,
+			500,
+			300,
+			400,
+			[0, 0, 100, 100],
+			'portfolio%2Fitem%201.png?fit=face&h=300&max-h=400&max-w=500&rect=0%2C0%2C100%2C100&w=400',
+			'da28c48a69db3445bc3093eee12d4b07',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgixFolderSourceTest.php
+++ b/Tests/Unit/Builder/ImgixFolderSourceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgixFolderSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgixFolderSourceTest extends UnitTestCase
+{
+	private ImgixFolderSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImgixFolderSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToIdentifierWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn('/user_upload/images/photo.png');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('user_upload/images/photo.png', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn('/fallback-identifier.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/youtube-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('typo3temp/assets/online_media/youtube-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn($inputUrl);
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path if present' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?auto=format&fit=max',
+			'banner.jpg?auto=format&fit=max',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ImgixProxySourceTest.php
+++ b/Tests/Unit/Builder/ImgixProxySourceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgixProxySource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgixProxySourceTest extends UnitTestCase
+{
+	private ImgixProxySource $subject;
+	private string $testHost = 'https://my-source.imgix.net';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ImgixProxySource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://my-source.imgix.net/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/vimeo-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://my-source.imgix.net/typo3temp/assets/online_media/vimeo-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://my-source.imgix.net/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://my-source.imgix.net/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?auto=format,compress',
+			'https://my-source.imgix.net/banner.jpg?auto=format,compress',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://my-source.imgix.net/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/OptimoleBuilderTest.php
+++ b/Tests/Unit/Builder/OptimoleBuilderTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\OptimoleBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class OptimoleBuilderTest extends UnitTestCase
+{
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new OptimoleBuilder('myapikey123');
+
+		$builder->setSource('images/hero.png')
+			->setType('resize')
+			->setGravity(OptimoleBuilder::GRAVITY_CENTER, 10, 20)
+			->setWidth(1920)
+			->setMinWidth(1024)
+			->setHeight(1080)
+			->setMinHeight(768)
+			->setCrop(400, 300, [OptimoleBuilder::GRAVITY_SMART])
+			->setHash('abcdef');
+
+		$this->assertSame('images/hero.png', $builder->getSource());
+		$this->assertSame('resize', $builder->getType());
+		$this->assertSame([OptimoleBuilder::GRAVITY_CENTER, 10, 20], $builder->getGravity());
+		$this->assertSame(1920, $builder->getWidth());
+		$this->assertSame(1024, $builder->getMinWidth());
+		$this->assertSame(1080, $builder->getHeight());
+		$this->assertSame(768, $builder->getMinHeight());
+		$this->assertSame([400, 300, OptimoleBuilder::GRAVITY_SMART], $builder->getCrop());
+		$this->assertSame('abcdef', $builder->getHash());
+	}
+
+	#[Test]
+	#[DataProvider('optimoleTransformationsDataProvider')]
+	public function buildGeneratesCorrectOptimoleUrlStructure(
+		?string $type,
+		?array $gravityArgs,
+		?int $w,
+		?int $mw,
+		?int $h,
+		?int $mh,
+		?array $cropArgs,
+		?string $hash,
+		string $expectedPath
+	): void {
+		$builder = new OptimoleBuilder('demo-key');
+		$builder->setSource('/uploads/media/test.jpg');
+
+		if ($type !== null) {
+			$builder->setType($type);
+		}
+		if ($gravityArgs !== null) {
+			$builder->setGravity(...$gravityArgs);
+		}
+		if ($w !== null) {
+			$builder->setWidth($w);
+		}
+		if ($mw !== null) {
+			$builder->setMinWidth($mw);
+		}
+		if ($h !== null) {
+			$builder->setHeight($h);
+		}
+		if ($mh !== null) {
+			$builder->setMinHeight($mh);
+		}
+		if ($cropArgs !== null) {
+			$builder->setCrop(...$cropArgs);
+		}
+		if ($hash !== null) {
+			$builder->setHash($hash);
+		}
+
+		$expectedUrl = 'https://demo-key.i.optimole.com/' . $expectedPath;
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function optimoleTransformationsDataProvider(): \Generator
+	{
+		yield 'basic scaling parameters' => [
+			'resize',
+			null,
+			800,
+			null,
+			600,
+			null,
+			null,
+			null,
+			'rt:resize/w:800/h:600/uploads/media/test.jpg',
+		];
+
+		yield 'min bounds and hash caching buster applied' => [
+			null,
+			null,
+			null,
+			400,
+			null,
+			300,
+			null,
+			'hashval99',
+			'mw:400/mh:300/cb:hashval99/uploads/media/test.jpg',
+		];
+
+		yield 'gravity parameters with optional offsets' => [
+			null,
+			[OptimoleBuilder::GRAVITY_TOP_LEFT, 50, null], // filter out null values automatically
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			'g:nowe:50/uploads/media/test.jpg',
+		];
+
+		yield 'crop options mapped cleanly using array structures' => [
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			[200, 200, [OptimoleBuilder::GRAVITY_CENTER]],
+			null,
+			'c:200:200:ce/uploads/media/test.jpg',
+		];
+
+		yield 'all options active synchronously' => [
+			'fit',
+			[OptimoleBuilder::GRAVITY_SMART, 10, 10],
+			1200,
+			800,
+			900,
+			600,
+			[500, 400, [OptimoleBuilder::GRAVITY_BOTTOM_RIGHT]],
+			'xyz',
+			'rt:fit/g:sm:10:10/w:1200/mw:800/h:900/mh:600/c:500:400:soea/cb:xyz/uploads/media/test.jpg',
+		];
+	}
+}

--- a/Tests/Unit/Builder/SirvBuilderTest.php
+++ b/Tests/Unit/Builder/SirvBuilderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SirvBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class SirvBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://demo.sirv.com';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new SirvBuilder(self::BASE_URL);
+
+		$builder->setSource('images/product.jpg')
+			->setScale('fit')
+			->setWidth(800)
+			->setHeight(600)
+			->setCrop(400, 300, 10, 20);
+
+		$this->assertSame('images/product.jpg', $builder->getSource());
+		$this->assertSame('fit', $builder->getScale());
+		$this->assertSame(800, $builder->getWidth());
+		$this->assertSame(600, $builder->getHeight());
+		$this->assertSame([400, 300, 10, 20], $builder->getCrop());
+	}
+
+	#[Test]
+	#[DataProvider('sirvTransformationsDataProvider')]
+	public function buildGeneratesCorrectSirvUrlStructure(
+		?string $scale,
+		?int $width,
+		?int $height,
+		?array $crop,
+		string $expectedQueryString
+	): void {
+		$builder = new SirvBuilder(self::BASE_URL);
+		$builder->setSource('/assets/test-image.png');
+
+		if ($scale !== null) {
+			$builder->setScale($scale);
+		}
+		if ($width !== null) {
+			$builder->setWidth($width);
+		}
+		if ($height !== null) {
+			$builder->setHeight($height);
+		}
+		if ($crop !== null) {
+			$builder->setCrop(...$crop);
+		}
+
+		$expectedUrl = 'https://demo.sirv.com/assets%2Ftest-image.png' . $expectedQueryString;
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function sirvTransformationsDataProvider(): \Generator
+	{
+		yield 'only scaling options' => [
+			'ignore',
+			500,
+			400,
+			null,
+			'?scale.option=ignore&w=500&h=400',
+		];
+
+		yield 'only crop coordinates mapping to cw, ch, cx, cy' => [
+			null,
+			null,
+			null,
+			[300, 200, 15, 25], // width, height, horizontal (x), vertical (y)
+			'?cw=300&ch=200&cx=15&cy=25',
+		];
+
+		yield 'all parameters joined sequentially' => [
+			'fit',
+			1024,
+			768,
+			[800, 600, 0, 0],
+			'?scale.option=fit&w=1024&h=768&cw=800&ch=600',
+		];
+
+		yield 'no query options when none provided' => [
+			null,
+			null,
+			null,
+			null,
+			'?',
+		];
+	}
+}

--- a/Tests/Unit/Builder/SirvUrlSourceTest.php
+++ b/Tests/Unit/Builder/SirvUrlSourceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SirvUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class SirvUrlSourceTest extends UnitTestCase
+{
+	private SirvUrlSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new SirvUrlSource();
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?w=800&q=80',
+			'banner.jpg?w=800&q=80',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ThumborBuilderTest.php
+++ b/Tests/Unit/Builder/ThumborBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ThumborBuilder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ThumborBuilderTest extends UnitTestCase
+{
+	private const BASE_URL = 'https://thumbor.example.com';
+
+	#[Test]
+	public function gettersAndSettersFunctionCorrectly(): void
+	{
+		$builder = new ThumborBuilder(self::BASE_URL, 'secret', 'sha256', 40);
+
+		$builder->setSource('images/photo.jpg')
+			->setType('fit-in')
+			->setWidth(800)
+			->setHeight(600)
+			->setCrop(100, 200, 10, 20);
+
+		$this->assertSame('images/photo.jpg', $builder->getSource());
+		$this->assertSame('fit-in', $builder->getType());
+		$this->assertSame(800, $builder->getWidth());
+		$this->assertSame(600, $builder->getHeight());
+		$this->assertSame([100, 200, 10, 20], $builder->getCrop());
+	}
+
+	#[Test]
+	public function buildReturnsUnsafePathWhenNoKeyIsProvided(): void
+	{
+		$builder = new ThumborBuilder(self::BASE_URL, null, 'sha256', 40);
+		$builder->setSource('my-image.jpg')
+			->setWidth(300)
+			->setHeight(200);
+
+		// Thumbor defaults to /unsafe/ when there is no key configured
+		$expectedUrl = 'https://thumbor.example.com/unsafe/300x200/my-image.jpg';
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	#[Test]
+	#[DataProvider('thumborPathDataProvider')]
+	public function buildGeneratesCorrectPathStructureAndSignature(
+		?string $type,
+		?int $width,
+		?int $height,
+		?array $crop,
+		string $expectedPath,
+		string $expectedSignature
+	): void {
+		// Constructing with a fixed test signing key and length restriction
+		$builder = new ThumborBuilder(self::BASE_URL, 'test-signing-key', 'sha256', 16);
+		$builder->setSource('folder/image.png');
+
+		if ($type !== null) {
+			$builder->setType($type);
+		}
+		if ($width !== null) {
+			$builder->setWidth($width);
+		}
+		if ($height !== null) {
+			$builder->setHeight($height);
+		}
+		if ($crop !== null) {
+			$builder->setCrop(...$crop);
+		}
+
+		$expectedUrl = sprintf('https://thumbor.example.com/%s/%s', $expectedSignature, $expectedPath);
+		$this->assertSame($expectedUrl, $builder->build());
+	}
+
+	public static function thumborPathDataProvider(): \Generator
+	{
+		yield 'only resizing width and height' => [
+			null,
+			400,
+			300,
+			null,
+			'400x300/folder%2Fimage.png',
+			'2rUP_K50ul8MXJ4R',
+		];
+
+		yield 'resizing using fit-in adaptation rule' => [
+			'fit-in',
+			800,
+			600,
+			null,
+			'fit-in/800x600/folder%2Fimage.png',
+			'o8vUdcLSyNDjoWYL',
+		];
+
+		yield 'crop options calculate box boundaries correctly' => [
+			null,
+			null,
+			null,
+			[150, 100, 20, 30], // width, height, horizontal (x), vertical (y)
+			'20x30:170x130/folder%2Fimage.png', // x1xy1:x2xy2 format
+			'MQ5ciKFT6NSCOTcr',
+		];
+
+		yield 'everything active at once' => [
+			'fit-in',
+			120,
+			120,
+			[50, 50, 10, 10],
+			'10x10:60x60/fit-in/120x120/folder%2Fimage.png',
+			'n3txtT_DGgAtMYCT',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ThumborFileSourceTest.php
+++ b/Tests/Unit/Builder/ThumborFileSourceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ThumborFileSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ThumborFileSourceTest extends UnitTestCase
+{
+	private ThumborFileSource $subject;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ThumborFileSource();
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToIdentifierWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn('/user_upload/images/photo.png');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('user_upload/images/photo.png', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn('/fallback-identifier.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/youtube-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('typo3temp/assets/online_media/youtube-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getIdentifier')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path if present' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?unsafe=true',
+			'banner.jpg?unsafe=true',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Builder/ThumborUrlSourceTest.php
+++ b/Tests/Unit/Builder/ThumborUrlSourceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Builder;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ThumborUrlSource;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ThumborUrlSourceTest extends UnitTestCase
+{
+	private ThumborUrlSource $subject;
+	private string $testHost = 'https://thumbor.my-domain.com';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->subject = new ThumborUrlSource($this->testHost);
+		$this->resetSingletonInstances = true;
+	}
+
+	#[Test]
+	public function getSourceFallsBackToPublicUrlWhenPreviewImageIsMissing(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('https://cdn.example.com/fileadmin/image.png?v=2');
+
+		// Mock the TYPO3 registry structure so OnlineMediaUtility returns null
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://thumbor.my-domain.com/fileadmin/image.png?v=2', $result);
+	}
+
+	#[Test]
+	public function getSourceFavorsPreviewImageWhenRegistryFindsValidHelper(): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn('/fallback-path.jpg');
+
+		$helperStub = $this->createStub(OnlineMediaHelperInterface::class);
+		$helperStub
+			->method('getPreviewImage')
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/vimeo-video.jpg');
+
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn($helperStub);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame('https://thumbor.my-domain.com/typo3temp/assets/online_media/vimeo-video.jpg', $result);
+	}
+
+	#[Test]
+	#[DataProvider('urlParsingDataProvider')]
+	public function buildPipelineCorrectlyFormatsVariousUrlStructures(string $inputUrl, string $expectedOutput): void
+	{
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getPublicUrl')
+			->willReturn($inputUrl);
+
+		// Ensure OnlineMediaUtility falls through cleanly to our data provider URL strings
+		$registryStub = $this->createStub(OnlineMediaHelperRegistry::class);
+		$registryStub
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryStub);
+
+		$result = $this->subject->getSource($fileStub);
+
+		$this->assertSame($expectedOutput, $result);
+	}
+
+	public static function urlParsingDataProvider(): \Generator
+	{
+		yield 'leading slash is trimmed' => [
+			'/fileadmin/assets/photo.jpg',
+			'https://thumbor.my-domain.com/fileadmin/assets/photo.jpg',
+		];
+
+		yield 'domain structure is discarded from input path' => [
+			'https://external-storage.com/subfolder/pic.jpg',
+			'https://thumbor.my-domain.com/subfolder/pic.jpg',
+		];
+
+		yield 'query string appended via suffix' => [
+			'/banner.jpg?unsafe=true',
+			'https://thumbor.my-domain.com/banner.jpg?unsafe=true',
+		];
+
+		yield 'empty or missing query strings ignored cleanly' => [
+			'/images/logo.png?',
+			'https://thumbor.my-domain.com/images/logo.png',
+		];
+	}
+}

--- a/Tests/Unit/Event/MediaProcessedEventTest.php
+++ b/Tests/Unit/Event/MediaProcessedEventTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Event;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Builder\BuilderInterface;
+use SomehowDigital\Typo3\MediaProcessing\Event\MediaProcessedEvent;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class MediaProcessedEventTest extends UnitTestCase
+{
+	#[Test]
+	public function constructorSetsInitialPropertiesCorrectly(): void
+	{
+		$taskStub = $this->createStub(TaskInterface::class);
+		$builderStub = $this->createStub(BuilderInterface::class);
+
+		$event = new MediaProcessedEvent($taskStub, $builderStub);
+
+		$this->assertSame($taskStub, $event->getTask());
+		$this->assertSame($builderStub, $event->getBuilder());
+	}
+
+	#[Test]
+	public function setBuilderOverwritesExistingBuilderInstance(): void
+	{
+		$taskStub = $this->createStub(TaskInterface::class);
+		$initialBuilderStub = $this->createStub(BuilderInterface::class);
+		$newBuilderStub = $this->createStub(BuilderInterface::class);
+
+		$event = new MediaProcessedEvent($taskStub, $initialBuilderStub);
+
+		$event->setBuilder($newBuilderStub);
+
+		$this->assertSame($newBuilderStub, $event->getBuilder());
+		$this->assertNotSame($initialBuilderStub, $event->getBuilder());
+	}
+}

--- a/Tests/Unit/EventListener/DocumentDimensionsEventListenerTest.php
+++ b/Tests/Unit/EventListener/DocumentDimensionsEventListenerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Page;
+use Smalot\PdfParser\Parser;
+use SomehowDigital\Typo3\MediaProcessing\EventListener\DocumentDimensionsEventListener;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ProviderInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Resource\Driver\DriverInterface;
+use TYPO3\CMS\Core\Resource\Event\BeforeFileProcessingEvent;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\MetaDataAspect;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class DocumentDimensionsEventListenerTest extends UnitTestCase
+{
+	private ProviderInterface&MockObject $providerMock;
+	private Parser&MockObject $parserMock;
+	private ExtensionConfiguration&MockObject $extensionConfiguration;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->providerMock = $this->createMock(ProviderInterface::class);
+		$this->parserMock = $this->createMock(Parser::class);
+		$this->extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+		$this->resetSingletonInstances = true;
+
+		$this->extensionConfiguration
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn([
+				'common' => [
+					'backend' => true,
+					'frontend' => true,
+					'private' => true,
+				],
+			]);
+
+		$GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())
+			->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+	}
+
+	#[Test]
+	public function doesNothingWhenWidthAlreadyExists(): void
+	{
+		$event = $this->createEvent(
+			width: 100
+		);
+
+		$this->providerMock
+			->expects($this->never())
+			->method('supports');
+
+		$this->parserMock
+			->expects($this->never())
+			->method('parseFile');
+
+		$listener = new DocumentDimensionsEventListener(
+			$this->providerMock,
+			$this->parserMock,
+			$this->extensionConfiguration
+		);
+
+		$listener($event);
+	}
+
+	#[Test]
+	public function doesNothingWhenProviderDoesNotSupportTask(): void
+	{
+		$event = $this->createEvent();
+
+		$this->providerMock
+			->expects($this->once())
+			->method('hasConfiguration')
+			->willReturn(true);
+
+		$this->providerMock
+			->expects($this->once())
+			->method('supports')
+			->willReturn(false);
+
+		$this->parserMock
+			->expects($this->never())
+			->method('parseFile');
+
+		$listener = new DocumentDimensionsEventListener(
+			$this->providerMock,
+			$this->parserMock,
+			$this->extensionConfiguration
+		);
+
+		$listener($event);
+	}
+
+	#[Test]
+	public function readsDimensionsFromPdf(): void
+	{
+		$metadataMock = $this->createMock(MetaDataAspect::class);
+
+		$metadataMock
+			->expects($this->once())
+			->method('add')
+			->with([
+				'width' => 595,
+				'height' => 842,
+			]);
+
+		$event = $this->createEvent(
+			metadata: $metadataMock
+		);
+
+		$this->providerMock
+			->expects($this->once())
+			->method('hasConfiguration')
+			->willReturn(true);
+
+		$this->providerMock
+			->expects($this->once())
+			->method('supports')
+			->willReturn(true);
+
+		$pageMock = $this->createMock(Page::class);
+
+		$pageMock
+			->expects($this->once())
+			->method('getDetails')
+			->willReturn([
+				'MediaBox' => [0, 0, 595, 842],
+			]);
+
+		$document = $this->createMock(Document::class);
+
+		$document
+			->expects($this->once())
+			->method('getPages')
+			->willReturn([$pageMock]);
+
+		$this->parserMock
+			->expects($this->once())
+			->method('parseFile')
+			->with('/tmp/document.pdf')
+			->willReturn($document);
+
+		$listener = new DocumentDimensionsEventListener(
+			$this->providerMock,
+			$this->parserMock,
+			$this->extensionConfiguration
+		);
+
+		$listener($event);
+	}
+
+	private function createEvent(
+		?int $width = null,
+		?int $height = null,
+		?MetaDataAspect $metadata = null
+	): BeforeFileProcessingEvent {
+		$storageMock = $this->createMock(ResourceStorage::class);
+
+		$storageMock
+			->expects($this->atLeastOnce())
+			->method('isOnline')
+			->willReturn(true);
+
+		$storageMock
+			->expects($this->atLeastOnce())
+			->method('isPublic')
+			->willReturn(true);
+
+		$fileStub = $this->createStub(File::class);
+
+		$fileStub->method('getStorage')->willReturn($storageMock);
+		$fileStub->method('exists')->willReturn(true);
+		$fileStub->method('getForLocalProcessing')->willReturn('/tmp/document.pdf');
+
+		$fileStub->method('getProperty')
+			->willReturnCallback(
+				static function (string $property) use ($width, $height) {
+					return match ($property) {
+						'width' => $width,
+						'height' => $height,
+						default => null,
+					};
+				}
+			);
+
+		$fileStub->method('getMetaData')
+			->willReturn($metadata ?? $this->createStub(MetaDataAspect::class));
+
+		$processedFileStub = $this->createStub(ProcessedFile::class);
+
+		$processedFileStub
+			->method('getTask')
+			->willReturn($this->createStub(TaskInterface::class));
+
+		return new BeforeFileProcessingEvent(
+			$this->createStub(DriverInterface::class),
+			$processedFileStub,
+			$fileStub,
+			'task',
+			[]
+		);
+	}
+}

--- a/Tests/Unit/Processor/MediaProcessorTest.php
+++ b/Tests/Unit/Processor/MediaProcessorTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Processor;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use SomehowDigital\Typo3\MediaProcessing\Builder\BuilderInterface;
+use SomehowDigital\Typo3\MediaProcessing\Event\MediaProcessedEvent;
+use SomehowDigital\Typo3\MediaProcessing\Processor\MediaProcessor;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ProviderInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class MediaProcessorTest extends UnitTestCase
+{
+	private ProviderInterface&MockObject $providerMock;
+	private EventDispatcherInterface&MockObject $dispatcherMock;
+	private ExtensionConfiguration&MockObject $extensionConfigurationMock;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->providerMock = $this->createMock(ProviderInterface::class);
+		$this->dispatcherMock = $this->createMock(EventDispatcherInterface::class);
+		$this->extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['TYPO3_REQUEST']);
+		parent::tearDown();
+	}
+
+	#[Test]
+	public function canProcessTaskReturnsTrueWhenAllConditionsAreMet(): void
+	{
+		$GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())
+			->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+
+		$storageMock = $this->createMock(ResourceStorage::class);
+
+		$storageMock
+			->expects($this->once())
+			->method('isOnline')
+			->willReturn(true);
+
+		$storageMock
+			->expects($this->once())
+			->method('isPublic')
+			->willReturn(false);
+		$sourceFileMock = $this->createMock(File::class);
+
+		$sourceFileMock
+			->expects($this->once())
+			->method('exists')
+			->willReturn(true);
+
+		$sourceFileMock
+			->expects($this->atLeastOnce())
+			->method('getProperty')
+			->willReturn(1920);
+
+		$sourceFileMock
+			->expects($this->atLeastOnce())
+			->method('getStorage')
+			->willReturn($storageMock);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+
+		$taskMock
+			->expects($this->atLeastOnce())
+			->method('getSourceFile')
+			->willReturn($sourceFileMock);
+
+		$this->extensionConfigurationMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn([
+				'common' => [
+					'backend' => true,
+					'private' => true,
+				],
+			]);
+
+		$this->providerMock
+			->expects($this->once())
+			->method('supports')
+			->with($taskMock)
+			->willReturn(true);
+
+		$this->providerMock
+			->expects($this->once())
+			->method('hasConfiguration')
+			->willReturn(true);
+
+		$this->dispatcherMock
+			->expects($this->never())
+			->method('dispatch');
+
+		$processor = new MediaProcessor(
+			$this->providerMock,
+			$this->dispatcherMock,
+			$this->extensionConfigurationMock
+		);
+
+		$this->assertTrue($processor->canProcessTask($taskMock));
+	}
+
+	#[Test]
+	public function canProcessTaskReturnsFalseIfBackendNotAllowedByConfig(): void
+	{
+		$GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())
+			->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
+
+		$this->dispatcherMock
+			->expects($this->never())
+			->method('dispatch');
+
+		$this->providerMock
+			->expects($this->never())
+			->method('hasConfiguration')
+			->willReturn(true);
+
+		$this->extensionConfigurationMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn([
+				'common' => ['frontend' => false],
+			]);
+
+		$processor = new MediaProcessor(
+			$this->providerMock,
+			$this->dispatcherMock,
+			$this->extensionConfigurationMock
+		);
+
+		$this->assertFalse($processor->canProcessTask($this->createStub(TaskInterface::class)));
+	}
+
+	#[Test]
+	public function processTaskReturnsEarlyIfChecksumMatches(): void
+	{
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+
+		$targetFileMock
+			->expects($this->once())
+			->method('getProperty')
+			->with('checksum')
+			->willReturn('matched-checksum');
+
+		$targetFileMock
+			->expects($this->never())
+			->method('setName');
+
+		$taskMock = $this->createMock(TaskInterface::class);
+
+		$taskMock
+			->expects($this->once())
+			->method('getConfigurationChecksum')
+			->willReturn('matched-checksum');
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		$taskMock
+			->expects($this->once())
+			->method('setExecuted')
+			->with(true);
+
+		$this->extensionConfigurationMock
+			->expects($this->once())
+			->method('get');
+
+		$this->providerMock
+			->expects($this->never())
+			->method('supports')
+			->with($taskMock)
+			->willReturn(true);
+
+		$this->dispatcherMock
+			->expects($this->never())
+			->method('dispatch');
+
+		$processor = new MediaProcessor(
+			$this->providerMock,
+			$this->dispatcherMock,
+			$this->extensionConfigurationMock
+		);
+
+		$processor->processTask($taskMock);
+	}
+
+	#[Test]
+	public function processTaskExecutesAndDispatchesEvent(): void
+	{
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+
+		$targetFileMock
+			->expects($this->once())
+			->method('getProperty')
+			->with('checksum')
+			->willReturn('other-checksum');
+
+		$targetFileMock
+			->expects($this->once())
+			->method('setName')
+			->with('processed_image.jpg');
+
+		$targetFileMock
+			->expects($this->once())
+			->method('updateProperties')
+			->with([
+				'width' => 800,
+				'height' => 600,
+				'checksum' => 'new-checksum',
+				'processing_url' => 'https://example.com/media/image.jpg',
+			]);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+
+		$taskMock
+			->expects($this->atLeastOnce())
+			->method('getConfigurationChecksum')
+			->willReturn('new-checksum');
+
+		$taskMock
+			->expects($this->atLeastOnce())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		$taskMock
+			->expects($this->atLeastOnce())
+			->method('getTargetFileName')
+			->willReturn('processed_image.jpg');
+
+		$taskMock
+			->expects($this->once())
+			->method('getConfiguration')->willReturn([
+				'crop' => new Area(0, 0, 800, 600),
+			]);
+
+		$builderMock = $this->createMock(BuilderInterface::class);
+
+		$builderMock->expects($this->once())
+			->method('build')
+			->willReturn('https://example.com/media/image.jpg');
+
+		$this->providerMock
+			->expects($this->once())
+			->method('configure')
+			->with($taskMock)
+			->willReturn($builderMock);
+
+		$this->dispatcherMock
+			->expects($this->once())
+			->method('dispatch')
+			->with($this->isInstanceOf(MediaProcessedEvent::class))
+			->willReturnArgument(0);
+
+		$taskMock
+			->expects($this->once())
+			->method('setExecuted')
+			->with(true);
+
+		$this->extensionConfigurationMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn([
+				'common' => ['storage' => false],
+			]);
+
+		$processor = new MediaProcessor(
+			$this->providerMock,
+			$this->dispatcherMock,
+			$this->extensionConfigurationMock
+		);
+
+		$processor->processTask($taskMock);
+	}
+}

--- a/Tests/Unit/Provider/BunnyProviderTest.php
+++ b/Tests/Unit/Provider/BunnyProviderTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\BunnyBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\BunnyProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class BunnyProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://myzone.b-cdn.net',
+			'signature' => true,
+			'signature_key' => 'bunny-secure-token-key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('bunny', BunnyProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new BunnyProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://myzone.b-cdn.net', $provider->getEndpoint());
+		$this->assertSame('bunny-secure-token-key', $provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function getSignatureKeyReturnsNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$provider = new BunnyProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-cdn-url';
+		$provider = new BunnyProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new BunnyProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new BunnyProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'application/pdf', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedBunnyBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new BunnyProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-bunny-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var BunnyBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(BunnyBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding to match target internal property structures
+		$this->assertSame('resolved-bunny-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Width and height configuration values' => [
+			['width' => '150', 'height' => '250'],
+			['width' => 150, 'height' => 250],
+		];
+
+		yield 'Fallback using maxWidth and maxHeight values' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			['width' => 600, 'height' => 400],
+		];
+
+		yield 'Crop area boundaries mapped directly to options integers' => [
+			[
+				'crop' => new Area(15, 25, 300, 150),
+			],
+			[
+				'crop' => [
+					300,
+					150,
+					15,
+					25,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/CloudImageProviderTest.php
+++ b/Tests/Unit/Provider/CloudImageProviderTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudImageBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\CloudImageProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudImageProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://token.cloudimg.io',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'cloudimage-secret-key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('cloudimage', CloudImageProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new CloudImageProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://token.cloudimg.io', $provider->getEndpoint());
+		$this->assertSame('cloudimage-secret-key', $provider->getSignatureKey());
+		$this->assertSame($this->sourceStub, $provider->getSource());
+	}
+
+	#[Test]
+	public function getSignatureKeyReturnsNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$provider = new CloudImageProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function hasConfigurationValidatesCorrectly(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = '';
+		$providerWithoutConfig = new CloudImageProvider($this->sourceStub, $options);
+		$this->assertFalse($providerWithoutConfig->hasConfiguration());
+
+		$providerWithConfig = new CloudImageProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($providerWithConfig->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new CloudImageProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/tiff', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedCloudImageBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new CloudImageProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-cloudimage-source');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var CloudImageBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(CloudImageBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding
+		$this->assertSame('resolved-cloudimage-source', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['function'], (fn() => $this->function)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to cover' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'function' => 'cover',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'Crop mode matching suffix c' => [
+			['width' => '400c', 'height' => '250'],
+			[
+				'function' => 'crop',
+				'width' => 400,
+				'height' => 250,
+			],
+		];
+
+		yield 'Bound mode matching suffix m' => [
+			['width' => '500m'],
+			[
+				'function' => 'bound',
+				'width' => 500,
+			],
+		];
+
+		yield 'Bound mode via explicit max dimensions' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			[
+				'function' => 'bound',
+				'width' => 600,
+				'height' => 400,
+			],
+		];
+
+		yield 'Crop area boundaries mapped cleanly' => [
+			[
+				'crop' => new Area(10, 20, 300, 150),
+			],
+			[
+				'function' => 'cover',
+				'crop' => [
+					10,
+					20,
+					300,
+					150,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/CloudflareProviderTest.php
+++ b/Tests/Unit/Provider/CloudflareProviderTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudflareBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\CloudflareProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudflareProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://images.example.com',
+			'source_uri' => 'https://origin.example.com',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('cloudflare', CloudflareProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new CloudflareProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://images.example.com', $provider->getEndpoint());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'not-a-valid-url';
+		$provider = new CloudflareProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new CloudflareProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new CloudflareProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'application/pdf', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedCloudflareBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new CloudflareProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getProperty')
+			->willReturnMap([
+				['width', 1000],
+				['height', 800],
+			]);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-cloudflare-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var CloudflareBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(CloudflareBuilder::class, $builder);
+
+		// Reflection-less closure extraction to verify internal properties
+		$this->assertSame('resolved-cloudflare-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['fit'] ?? 'contain', (fn() => $this->fit)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['trim'] ?? null, (fn() => $this->trim)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default fit contain mapping with standard dimensions' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'fit' => 'contain',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'Cover fit switch via width suffix c' => [
+			['width' => '400c', 'maxHeight' => 300],
+			[
+				'fit' => 'cover',
+				'width' => 400,
+				'height' => 300,
+			],
+		];
+
+		yield 'Crop trimming calculation relative to 1000x800 base boundaries' => [
+			[
+				// Area: left=50, top=60, width=400, height=300
+				'crop' => new Area(50, 60, 400, 300),
+			],
+			[
+				'fit' => 'contain',
+				'trim' => [
+					60,
+					550,
+					440,
+					50,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/CloudinaryProviderTest.php
+++ b/Tests/Unit/Provider/CloudinaryProviderTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\CloudinaryBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\CloudinaryProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class CloudinaryProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://api.cloudinary.com/v1_1/demo/image/fetch',
+			'delivery_mode' => 'fetch',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_algorithm' => 'sha256',
+			'signature_key' => 'cloudinary-secret-key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('cloudinary', CloudinaryProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new CloudinaryProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://api.cloudinary.com/v1_1/demo/image/fetch', $provider->getEndpoint());
+		$this->assertSame('cloudinary-secret-key', $provider->getSignatureKey());
+		$this->assertSame('sha256', $provider->getSignatureAlgorithm());
+		$this->assertSame($this->sourceStub, $provider->getSource());
+	}
+
+	#[Test]
+	public function signatureGettersReturnNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$options['signature_algorithm'] = '';
+		$provider = new CloudinaryProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+		$this->assertNull($provider->getSignatureAlgorithm());
+	}
+
+	#[Test]
+	public function hasConfigurationValidatesCorrectly(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = '';
+		$providerWithoutConfig = new CloudinaryProvider($this->sourceStub, $options);
+		$this->assertFalse($providerWithoutConfig->hasConfiguration());
+
+		$providerWithConfig = new CloudinaryProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($providerWithConfig->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new CloudinaryProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported tiff format' => ['Preview', 'image/tiff', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/x-unsupported', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedCloudinaryBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new CloudinaryProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-cloudinary-source');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var CloudinaryBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(CloudinaryBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding
+		$this->assertSame('resolved-cloudinary-source', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['mode'], (fn() => $this->mode)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default fit fallback mapping maps to scale' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'mode' => 'scale',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'Fill mode matching width suffix c' => [
+			['width' => '400c', 'height' => '250'],
+			[
+				'mode' => 'fill',
+				'width' => 400,
+				'height' => 250,
+			],
+		];
+
+		yield 'Fit mode matching height suffix m' => [
+			['height' => '500m'],
+			[
+				'mode' => 'fit',
+				'height' => 500,
+			],
+		];
+
+		yield 'Fit mode via explicit max dimensions' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			[
+				'mode' => 'fit',
+				'width' => 600,
+				'height' => 400,
+			],
+		];
+
+		yield 'Crop area boundaries mapped cleanly' => [
+			[
+				'crop' => new Area(12, 24, 320, 160),
+			],
+			[
+				'mode' => 'scale',
+				'crop' => [
+					12,
+					24,
+					320,
+					160,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/GumletProviderTest.php
+++ b/Tests/Unit/Provider/GumletProviderTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\GumletBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\GumletProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class GumletProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://demo.gumlet.io',
+			'source_loader' => 'folder',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'gumlet-secure-token-key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('gumlet', GumletProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new GumletProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://demo.gumlet.io', $provider->getEndpoint());
+		$this->assertTrue($provider->hasSignature());
+		$this->assertSame('gumlet-secure-token-key', $provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function getSignatureKeyReturnsNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$provider = new GumletProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-gumlet-url';
+		$provider = new GumletProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new GumletProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new GumletProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported jxl format' => ['Preview', 'image/jxl', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/tiff-unsupported', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedGumletBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new GumletProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-gumlet-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var GumletBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(GumletBuilder::class, $builder);
+
+		// Reflection-less property verification via Closure binding scope
+		$this->assertSame('resolved-gumlet-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Width and height explicit values' => [
+			['width' => '220', 'height' => '330'],
+			['width' => 220, 'height' => 330],
+		];
+
+		yield 'Fallback mapping utilizing maxWidth and maxHeight rules' => [
+			['maxWidth' => 800, 'maxHeight' => 600],
+			['width' => 800, 'height' => 600],
+		];
+
+		yield 'Crop area boundaries mapped into builder schema integers' => [
+			[
+				'crop' => new Area(8, 16, 400, 200),
+			],
+			[
+				'crop' => [
+					8,
+					16,
+					400,
+					200,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ImageKitProviderTest.php
+++ b/Tests/Unit/Provider/ImageKitProviderTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImageKitBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ImageKitProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImageKitProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://ik.imagekit.io/mycompany',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'imagekit-private-key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('imagekit', ImageKitProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new ImageKitProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://ik.imagekit.io/mycompany', $provider->getEndpoint());
+		$this->assertSame('imagekit-private-key', $provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function getSignatureKeyReturnsNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$provider = new ImageKitProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-endpoint';
+		$provider = new ImageKitProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new ImageKitProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new ImageKitProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported svg format' => ['Preview', 'image/svg', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'application/pdf', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedImageKitBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new ImageKitProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-imagekit-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var ImageKitBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(ImageKitBuilder::class, $builder);
+
+		// Reflection-less context property validation via Closure binding scope
+		$this->assertSame('resolved-imagekit-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['mode'], (fn() => $this->mode)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to force' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'mode' => 'force',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'At_max mode via explicit max dimensions' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			[
+				'mode' => 'at_max',
+				'width' => 600,
+				'height' => 400,
+			],
+		];
+
+		yield 'At_max mode matching width suffix m' => [
+			['width' => '500m'],
+			[
+				'mode' => 'at_max',
+				'width' => 500,
+			],
+		];
+
+		yield 'Maintain_ratio mode matching height suffix c' => [
+			['height' => '450c'],
+			[
+				'mode' => 'maintain_ratio',
+				'height' => 450,
+			],
+		];
+
+		yield 'Crop area boundaries structural assignments' => [
+			[
+				'crop' => new Area(10, 20, 350, 180),
+			],
+			[
+				'mode' => 'force',
+				'crop' => [
+					350,
+					180,
+					10,
+					20,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ImagorProviderTest.php
+++ b/Tests/Unit/Provider/ImagorProviderTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImagorBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ImagorProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImagorProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://imagor.example.com',
+			'source_loader' => 'uri',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'imagor-secret-key',
+			'signature_algorithm' => 'sha256',
+			'signature_length' => 40,
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('imagor', ImagorProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new ImagorProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://imagor.example.com', $provider->getEndpoint());
+		$this->assertSame('imagor-secret-key', $provider->getSignatureKey());
+		$this->assertSame('sha256', $provider->getSignatureAlgorithm());
+		$this->assertSame(40, $provider->getSignatureLength());
+	}
+
+	#[Test]
+	public function signatureGettersReturnNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$options['signature_algorithm'] = '';
+		$options['signature_length'] = null;
+		$provider = new ImagorProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+		$this->assertNull($provider->getSignatureAlgorithm());
+		$this->assertNull($provider->getSignatureLength());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-imagor-url';
+		$provider = new ImagorProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new ImagorProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new ImagorProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported bmp format' => ['Preview', 'image/bmp', true];
+		yield 'Supported tiff format' => ['Preview', 'image/tiff', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'application/pdf', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedImagorBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new ImagorProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-imagor-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var ImagorBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(ImagorBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding scope
+		$this->assertSame('resolved-imagor-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['type'], (fn() => $this->type)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to stretch' => [
+			['width' => '400', 'height' => '300'],
+			[
+				'type' => 'stretch',
+				'width' => 400,
+				'height' => 300,
+			],
+		];
+
+		yield 'Fit-in mode matching width suffix m' => [
+			['width' => '500m'],
+			[
+				'type' => 'fit-in',
+				'width' => 500,
+			],
+		];
+
+		yield 'Fit-in mode matching height suffix c' => [
+			['height' => '600c'],
+			[
+				'type' => 'fit-in',
+				'height' => 600,
+			],
+		];
+
+		yield 'Fit-in mode via explicit max dimensions' => [
+			['maxWidth' => 800, 'maxHeight' => 600],
+			[
+				'type' => 'fit-in',
+				'width' => 800,
+				'height' => 600,
+			],
+		];
+
+		yield 'Crop area boundaries structural mapping' => [
+			[
+				'crop' => new Area(15, 30, 450, 250),
+			],
+			[
+				'type' => 'stretch',
+				'crop' => [
+					450,
+					250,
+					15,
+					30,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ImgLabProviderTest.php
+++ b/Tests/Unit/Provider/ImgLabProviderTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgLabBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ImgLabProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgLabProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://assets.imglab-cdn.net',
+			'source_loader' => 'web',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'imglab-secret-key',
+			'signature_salt' => 'imglab-secret-salt',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('imglab', ImgLabProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new ImgLabProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://assets.imglab-cdn.net', $provider->getEndpoint());
+		$this->assertTrue($provider->hasSignature());
+		$this->assertSame('imglab-secret-key', $provider->getSignatureKey());
+		$this->assertSame('imglab-secret-salt', $provider->getSignatureSalt());
+	}
+
+	#[Test]
+	public function signatureGettersReturnNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$options['signature_salt'] = '';
+		$provider = new ImgLabProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+		$this->assertNull($provider->getSignatureSalt());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-imglab-url';
+		$provider = new ImgLabProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new ImgLabProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new ImgLabProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported jp2 format' => ['Preview', 'image/jp2', true];
+		yield 'Supported jpx format' => ['Preview', 'image/jpx', true];
+		yield 'Supported jpm format' => ['Preview', 'image/jpm', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/tiff', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedImgLabBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new ImgLabProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-imglab-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var ImgLabBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(ImgLabBuilder::class, $builder);
+
+		// Reflection-less property verification via Closure binding scope
+		$this->assertSame('resolved-imglab-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['mode'], (fn() => $this->mode)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['region'] ?? null, (fn() => $this->region)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to clip' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'mode' => 'clip',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'Crop mode matching width suffix c' => [
+			['width' => '400c', 'height' => '250'],
+			[
+				'mode' => 'crop',
+				'width' => 400,
+				'height' => 250,
+			],
+		];
+
+		yield 'Clip mode via explicit max dimensions fallback' => [
+			['maxWidth' => 500, 'maxHeight' => 350],
+			[
+				'mode' => 'clip',
+				'width' => 500,
+				'height' => 350,
+			],
+		];
+
+		yield 'Crop area boundaries mapped into builder region properties' => [
+			[
+				'crop' => new Area(15, 25, 450, 220),
+			],
+			[
+				'mode' => 'clip',
+				'region' => [
+					15,
+					25,
+					450,
+					220,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ImgProxyProviderTest.php
+++ b/Tests/Unit/Provider/ImgProxyProviderTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgProxyBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ImgProxyProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgProxyProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://imgproxy.example.com',
+			'signature_key' => 'secret_key',
+			'signature_salt' => 'secret_salt',
+			'signature_size' => 32,
+			'encryption_key' => 'encrypt_key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('imgproxy', ImgProxyProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new ImgProxyProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://imgproxy.example.com', $provider->getEndpoint());
+		$this->assertSame('secret_key', $provider->getSignatureKey());
+		$this->assertSame('secret_salt', $provider->getSignatureSalt());
+		$this->assertSame(32, $provider->getSignatureSize());
+		$this->assertSame('encrypt_key', $provider->getEncryptionKey());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-url';
+		$provider = new ImgProxyProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new ImgProxyProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $processingPdf, bool $expected): void
+	{
+		$options = $this->defaultOptions;
+		$options['processing_pdf'] = $processingPdf;
+		$provider = new ImgProxyProvider($this->sourceStub, $options);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and image mime type' => ['Preview', 'image/jpeg', false, true];
+		yield 'Supported CropScaleMask task' => ['CropScaleMask', 'image/png', false, true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false, false];
+		yield 'Unsupported mime type' => ['Preview', 'image/tiff-unsupported', false, false];
+		yield 'PDF supported when processing_pdf is true' => ['Preview', 'application/pdf', true, true];
+		yield 'PDF unsupported when processing_pdf is false' => ['Preview', 'application/pdf', false, false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedImgProxyBuilder(array $processingConfig, string $expectedType, array $expectedDimensions): void
+	{
+		$provider = new ImgProxyProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileMock = $this->createMock(File::class);
+		$fileMock
+			->expects($this->once())
+			->method('getSha1')
+			->willReturn('mocked-sha1-hash');
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileMock);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var ImgProxyBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(ImgProxyBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding
+		$this->assertSame($expectedType, (fn() => $this->type)->call($builder), 'Type mapping failed');
+		$this->assertSame($expectedDimensions['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedDimensions['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedDimensions['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Force type mapping default' => [
+			['width' => '100', 'height' => '200'],
+			'force',
+			['width' => 100, 'height' => 200],
+		];
+		yield 'Fit type mapping via max dimensions' => [
+			['maxWidth' => 400, 'maxHeight' => 300],
+			'fit',
+			['width' => 400, 'height' => 300],
+		];
+		yield 'Fit type mapping via suffix' => [
+			['width' => '400m'],
+			'fit',
+			['width' => 400],
+		];
+		yield 'Fill type mapping via suffix' => [
+			['height' => '500c'],
+			'fill',
+			['height' => 500],
+		];
+		yield 'Crop dimension mapping via coordinates' => [
+			[
+				'crop' => new Area(10, 20, 100, 200),
+			],
+			'force',
+			[
+				'crop' => [
+					100,
+					200,
+					'nowe',
+					10,
+					20,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ImgixProviderTest.php
+++ b/Tests/Unit/Provider/ImgixProviderTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ImgixBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ImgixProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ImgixProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://my-source.imgix.net',
+			'source_loader' => 'folder',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'imgix-secure-token-key',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('imgix', ImgixProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new ImgixProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://my-source.imgix.net', $provider->getEndpoint());
+		$this->assertSame('imgix-secure-token-key', $provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function getSignatureKeyReturnsNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$provider = new ImgixProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-imgix-url';
+		$provider = new ImgixProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new ImgixProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new ImgixProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported bmp format' => ['Preview', 'image/bmp', true];
+		yield 'Supported eps format' => ['Preview', 'image/eps', true];
+		yield 'Supported tiff format' => ['Preview', 'image/tiff', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/x-unsupported', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedImgixBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new ImgixProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-imgix-source-path');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var ImgixBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(ImgixBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding scope
+		$this->assertSame('resolved-imgix-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['fit'], (fn() => $this->fit)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['rect'] ?? null, (fn() => $this->rect)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to scale' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'fit' => 'scale',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'Crop fit mode matching width suffix c' => [
+			['width' => '400c', 'height' => '250'],
+			[
+				'fit' => 'crop',
+				'width' => 400,
+				'height' => 250,
+			],
+		];
+
+		yield 'Clip fit mode matching height suffix m' => [
+			['height' => '500m'],
+			[
+				'fit' => 'clip',
+				'height' => 500,
+			],
+		];
+
+		yield 'Clip fit mode via explicit max dimensions' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			[
+				'fit' => 'clip',
+				'width' => 600,
+				'height' => 400,
+			],
+		];
+
+		yield 'Crop area boundaries mapped into builder rectangle array parameters' => [
+			[
+				'crop' => new Area(10, 20, 350, 180),
+			],
+			[
+				'fit' => 'scale',
+				'rect' => [
+					10,
+					20,
+					350,
+					180,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/OptimoleProviderTest.php
+++ b/Tests/Unit/Provider/OptimoleProviderTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\OptimoleBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\OptimoleProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class OptimoleProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_key' => 'optimole-key-12345',
+			'source_uri' => 'https://origin.example.com',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('optimole', OptimoleProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersAndEndpointTemplateReturnConfiguredValues(): void
+	{
+		$provider = new OptimoleProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('optimole-key-12345', $provider->getKey());
+
+		// Verifies strtr replacement behaves exactly as expected against the template constant
+		$expectedEndpoint = strtr(OptimoleBuilder::API_ENDPOINT_TEMPLATE, ['%key%' => 'optimole-key-12345']);
+		$this->assertSame($expectedEndpoint, $provider->getEndpoint());
+	}
+
+	#[Test]
+	public function getKeyReturnsNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_key'] = '';
+		$provider = new OptimoleProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getKey());
+	}
+
+	#[Test]
+	public function hasConfigurationValidatesCorrectly(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_key'] = '';
+		$providerWithoutConfig = new OptimoleProvider($this->sourceStub, $options);
+		$this->assertFalse($providerWithoutConfig->hasConfiguration());
+
+		$providerWithConfig = new OptimoleProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($providerWithConfig->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new OptimoleProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported ico format' => ['Preview', 'image/ico', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported tiff format' => ['Preview', 'image/tiff', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/x-unknown-raw', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedOptimoleBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new OptimoleProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileMock = $this->createMock(File::class);
+		$fileMock
+			->expects($this->once())
+			->method('getSha1')
+			->willReturn('mocked-file-sha1');
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-optimole-source');
+
+		$targetFileMock = $this->createMock(ProcessedFile::class);
+		$targetFileMock
+			->expects($this->once())
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskMock = $this->createMock(TaskInterface::class);
+		$taskMock
+			->expects($this->once())
+			->method('getSourceFile')
+			->willReturn($fileMock);
+
+		$taskMock
+			->expects($this->once())
+			->method('getTargetFile')
+			->willReturn($targetFileMock);
+
+		/** @var OptimoleBuilder $builder */
+		$builder = $provider->configure($taskMock);
+
+		$this->assertInstanceOf(OptimoleBuilder::class, $builder);
+
+		// Context internal property validation via Closure binding scope
+		$this->assertSame('resolved-optimole-source', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['type'], (fn() => $this->type)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['minWidth'] ?? null, (fn() => $this->minWidth)->call($builder));
+		$this->assertSame($expectedProperties['minHeight'] ?? null, (fn() => $this->minHeight)->call($builder));
+		$this->assertSame('mocked-file-sha1', (fn() => $this->hash)->call($builder));
+
+		if (isset($expectedProperties['crop'])) {
+			$this->assertSame($expectedProperties['crop'], (fn() => $this->crop)->call($builder));
+		}
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to force' => [
+			['width' => '300', 'height' => '200', 'minWidth' => 100, 'minHeight' => 50],
+			[
+				'type' => 'force',
+				'width' => 300,
+				'height' => 200,
+				'minWidth' => 100,
+				'minHeight' => 50,
+			],
+		];
+
+		yield 'Fit mode matching width suffix m' => [
+			['width' => '400m'],
+			[
+				'type' => 'fit',
+				'width' => 400,
+			],
+		];
+
+		yield 'Fit mode via explicit max dimensions fallback' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			[
+				'type' => 'fit',
+				'width' => 600,
+				'height' => 400,
+			],
+		];
+
+		yield 'Fill mode matching height suffix c' => [
+			['height' => '500c'],
+			[
+				'type' => 'fill',
+				'height' => 500,
+			],
+		];
+
+		yield 'Crop area boundaries mapped with top-left gravity payload array' => [
+			[
+				'crop' => new Area(10, 20, 350, 180),
+			],
+			[
+				'type' => 'force',
+				'crop' => [
+					350,
+					180,
+					'nowe',
+					10,
+					20,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ProviderFactoryTest.php
+++ b/Tests/Unit/Provider/ProviderFactoryTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use SomehowDigital\Typo3\MediaProcessing\Provider\BunnyProvider;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ImgProxyProvider;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ProviderFactory;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ProviderFactoryTest extends UnitTestCase
+{
+	private ExtensionConfiguration&MockObject $extensionConfigurationMock;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
+	}
+
+	#[Test]
+	public function invokeReturnsNullOnUnknownProvider(): void
+	{
+		$this->extensionConfigurationMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn([
+				'common' => ['provider' => 'unknown_provider'],
+				'provider' => [],
+			]);
+
+		$factory = new ProviderFactory($this->extensionConfigurationMock);
+
+		$this->assertNull($factory());
+	}
+
+	#[Test]
+	#[DataProvider('providerConfigDataProvider')]
+	public function invokeReturnsCorrectProviderInstance(array $mockConfig, string $expectedInstanceOf): void
+	{
+		$this->extensionConfigurationMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn($mockConfig);
+
+		$factory = new ProviderFactory($this->extensionConfigurationMock);
+		$result = $factory();
+
+		$this->assertInstanceOf($expectedInstanceOf, $result);
+	}
+
+	/**
+	 * Data provider using positional arrays within the generator.
+	 */
+	public static function providerConfigDataProvider(): \Generator
+	{
+		yield 'Bunny Provider' => [
+			[
+				'common' => ['provider' => 'bunny'],
+				'provider' => [
+					'bunny' => [],
+				],
+			],
+			BunnyProvider::class,
+		];
+
+		yield 'ImgProxy Provider with Uri Source' => [
+			[
+				'common' => ['provider' => 'imgproxy'],
+				'provider' => [
+					'imgproxy' => [
+						'source_loader' => 'uri',
+						'source_uri' => 'https://example.com',
+					],
+				],
+			],
+			ImgProxyProvider::class,
+		];
+
+		yield 'ImgProxy Provider with File Source' => [
+			[
+				'common' => ['provider' => 'imgproxy'],
+				'provider' => [
+					'imgproxy' => [
+						'source_loader' => 'file',
+					],
+				],
+			],
+			ImgProxyProvider::class,
+		];
+	}
+}

--- a/Tests/Unit/Provider/SirvProviderTest.php
+++ b/Tests/Unit/Provider/SirvProviderTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SirvBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Provider\SirvProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class SirvProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://myaccount.sirv.com',
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('sirv', SirvProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new SirvProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://myaccount.sirv.com', $provider->getEndpoint());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-sirv-url';
+		$provider = new SirvProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new SirvProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new SirvProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported heic format' => ['Preview', 'image/heic', true];
+		yield 'Supported bmp format' => ['Preview', 'image/bmp', true];
+		yield 'Supported eps format' => ['Preview', 'image/eps', true];
+		yield 'Supported tiff format' => ['Preview', 'image/tiff', true];
+		yield 'Supported pdf format' => ['Preview', 'application/pdf', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'image/x-unsupported', false];
+	}
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedSirvBuilder(array $processingConfig, array $expectedProperties): void
+	{
+		$provider = new SirvProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getProperty')
+			->willReturnCallback(static function (string $propertyName) {
+				return match ($propertyName) {
+					'width' => 1000,
+					'height' => 800,
+					default => null,
+				};
+			});
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-sirv-source-path');
+
+		$targetFileStub = $this->createStub(ProcessedFile::class);
+		$targetFileStub
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$targetFileStub
+			->method('getOriginalFile')
+			->willReturn($fileStub);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskStub
+			->method('getTargetFile')
+			->willReturn($targetFileStub);
+
+		// Required setup for internal execution of ImageDimension::fromProcessingTask($task)
+		$targetFileStub->method('getTask')->willReturn($taskStub);
+
+		/** @var SirvBuilder $builder */
+		$builder = $provider->configure($taskStub);
+
+		$this->assertInstanceOf(SirvBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding scope
+		$this->assertSame('resolved-sirv-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedProperties['scale'], (fn() => $this->scale)->call($builder));
+		$this->assertSame($expectedProperties['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedProperties['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedProperties['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Default switch fallback maps to ignore' => [
+			['width' => '300', 'height' => '200'],
+			[
+				'scale' => 'ignore',
+				'width' => 300,
+				'height' => 200,
+			],
+		];
+
+		yield 'Fill scale mode matching width suffix c' => [
+			['width' => '400c', 'height' => '250'],
+			[
+				'scale' => 'fill',
+				'width' => 400,
+				'height' => 250,
+			],
+		];
+
+		yield 'Fit scale mode matching height suffix m' => [
+			['height' => '500m'],
+			[
+				'scale' => 'fit',
+				'width' => 0,
+				'height' => 500,
+			],
+		];
+
+		yield 'Fit scale mode via explicit max dimensions' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			[
+				'scale' => 'fit',
+				'width' => 600,
+				'height' => 400,
+			],
+		];
+
+		yield 'Crop area dynamic boundaries scaling math relative to 2000x1600 base layout' => [
+			[
+				'crop' => new Area(100, 50, 500, 400),
+				'width' => 500,
+				'height' => 400,
+			],
+			[
+				'scale' => 'ignore',
+				'width' => 2000,
+				'height' => 1600,
+				'crop' => [
+					1000,
+					800,
+					200,
+					100,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Provider/ThumborProviderTest.php
+++ b/Tests/Unit/Provider/ThumborProviderTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Builder\SourceInterface;
+use SomehowDigital\Typo3\MediaProcessing\Builder\ThumborBuilder;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ThumborProvider;
+use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
+use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ThumborProviderTest extends UnitTestCase
+{
+	protected SourceInterface&Stub $sourceStub;
+	protected array $defaultOptions;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->sourceStub = $this->createStub(SourceInterface::class);
+		$this->defaultOptions = [
+			'api_endpoint' => 'https://thumbor.example.com',
+			'source_loader' => 'uri',
+			'source_uri' => 'https://origin.example.com',
+			'signature' => true,
+			'signature_key' => 'thumbor_secret_key',
+			'signature_algorithm' => 'sha256',
+			'signature_length' => 40,
+		];
+	}
+
+	#[Test]
+	public function getIdentifierReturnsCorrectString(): void
+	{
+		$this->assertSame('thumbor', ThumborProvider::getIdentifier());
+	}
+
+	#[Test]
+	public function gettersReturnConfiguredValues(): void
+	{
+		$provider = new ThumborProvider($this->sourceStub, $this->defaultOptions);
+
+		$this->assertSame('https://thumbor.example.com', $provider->getEndpoint());
+		$this->assertSame('thumbor_secret_key', $provider->getSignatureKey());
+		$this->assertSame('sha256', $provider->getSignatureAlgorithm());
+		$this->assertSame(40, $provider->getSignatureLength());
+	}
+
+	#[Test]
+	public function signatureGettersReturnNullWhenEmpty(): void
+	{
+		$options = $this->defaultOptions;
+		$options['signature_key'] = '';
+		$options['signature_algorithm'] = '';
+		$options['signature_length'] = null;
+		$provider = new ThumborProvider($this->sourceStub, $options);
+
+		$this->assertNull($provider->getSignatureKey());
+		$this->assertNull($provider->getSignatureAlgorithm());
+		$this->assertNull($provider->getSignatureLength());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	{
+		$options = $this->defaultOptions;
+		$options['api_endpoint'] = 'invalid-thumbor-endpoint';
+		$provider = new ThumborProvider($this->sourceStub, $options);
+
+		$this->assertFalse($provider->hasConfiguration());
+	}
+
+	#[Test]
+	public function hasConfigurationReturnsTrueForValidUrl(): void
+	{
+		$provider = new ThumborProvider($this->sourceStub, $this->defaultOptions);
+		$this->assertTrue($provider->hasConfiguration());
+	}
+
+	#[Test]
+	#[DataProvider('supportsDataProvider')]
+	public function supportsValidatesTaskCorrectly(string $taskName, string $mimeType, bool $expected): void
+	{
+		$provider = new ThumborProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+		$fileStub
+			->method('getMimeType')
+			->willReturn($mimeType);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getName')
+			->willReturn($taskName);
+
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$this->assertSame($expected, $provider->supports($taskStub));
+	}
+
+	public static function supportsDataProvider(): \Generator
+	{
+		yield 'Supported task and jpeg mime type' => ['Preview', 'image/jpeg', true];
+		yield 'Supported CropScaleMask task and png' => ['CropScaleMask', 'image/png', true];
+		yield 'Supported webp format' => ['Preview', 'image/webp', true];
+		yield 'Supported avif format' => ['Preview', 'image/avif', true];
+		yield 'Supported gif format' => ['Preview', 'image/gif', true];
+		yield 'Supported bmp format' => ['Preview', 'image/bmp', true];
+		yield 'Supported tiff format' => ['Preview', 'image/tiff', true];
+		yield 'Supported video helper youtube' => ['Preview', 'video/youtube', true];
+		yield 'Supported video helper vimeo' => ['Preview', 'video/vimeo', true];
+		yield 'Unsupported task name' => ['CustomTask', 'image/jpeg', false];
+		yield 'Unsupported mime type' => ['Preview', 'application/pdf', false];
+	}
+
+	#[Test]
+	#[DataProvider('configurationDataProvider')]
+	public function configureBuildsExpectedThumborBuilder(array $processingConfig, string $expectedType, array $expectedDimensions): void
+	{
+		$provider = new ThumborProvider($this->sourceStub, $this->defaultOptions);
+
+		$fileStub = $this->createStub(File::class);
+
+		$this->sourceStub
+			->method('getSource')
+			->willReturn('resolved-thumbor-source-path');
+
+		$targetFileStub = $this->createStub(ProcessedFile::class);
+		$targetFileStub
+			->method('getProcessingConfiguration')
+			->willReturn($processingConfig);
+
+		$taskStub = $this->createStub(TaskInterface::class);
+		$taskStub
+			->method('getSourceFile')
+			->willReturn($fileStub);
+
+		$taskStub
+			->method('getTargetFile')
+			->willReturn($targetFileStub);
+
+		/** @var ThumborBuilder $builder */
+		$builder = $provider->configure($taskStub);
+
+		$this->assertInstanceOf(ThumborBuilder::class, $builder);
+
+		// Reflection-less property check via Closure binding scope
+		$this->assertSame('resolved-thumbor-source-path', (fn() => $this->source)->call($builder));
+		$this->assertSame($expectedType, (fn() => $this->type)->call($builder), 'Type mapping failed');
+		$this->assertSame($expectedDimensions['width'] ?? null, (fn() => $this->width)->call($builder));
+		$this->assertSame($expectedDimensions['height'] ?? null, (fn() => $this->height)->call($builder));
+		$this->assertSame($expectedDimensions['crop'] ?? null, (fn() => $this->crop)->call($builder));
+	}
+
+	public static function configurationDataProvider(): \Generator
+	{
+		yield 'Stretch type mapping default fallback' => [
+			['width' => '300', 'height' => '200'],
+			'stretch',
+			['width' => 300, 'height' => 200],
+		];
+
+		yield 'Fit-in type mapping via width suffix m' => [
+			['width' => '400m'],
+			'fit-in',
+			['width' => 400],
+		];
+
+		yield 'Fit-in type mapping via height suffix m' => [
+			['height' => '500m'],
+			'fit-in',
+			['height' => 500],
+		];
+
+		yield 'Fit-in type mapping via width suffix c' => [
+			['width' => '400c'],
+			'fit-in',
+			['width' => 400],
+		];
+
+		yield 'Fit-in type mapping via height suffix c' => [
+			['height' => '500c'],
+			'fit-in',
+			['height' => 500],
+		];
+
+		yield 'Fit-in type mapping via explicit max dimensions' => [
+			['maxWidth' => 600, 'maxHeight' => 400],
+			'fit-in',
+			['width' => 600, 'height' => 400],
+		];
+
+		yield 'Crop dimension positional mapping assignments' => [
+			[
+				'crop' => new Area(15, 30, 450, 250),
+			],
+			'stretch',
+			[
+				'crop' => [
+					450,
+					250,
+					15,
+					30,
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/Report/Status/ServiceStatusTest.php
+++ b/Tests/Unit/Report/Status/ServiceStatusTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Report\Status;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use SomehowDigital\Typo3\MediaProcessing\Provider\ProviderInterface;
+use SomehowDigital\Typo3\MediaProcessing\Report\Status\ServiceStatus;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Reports\Status;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ServiceStatusTest extends UnitTestCase
+{
+	protected ExtensionConfiguration&MockObject $extensionConfigMock;
+	protected LanguageService&Stub $languageServiceStub;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->extensionConfigMock = $this->createMock(ExtensionConfiguration::class);
+		$this->languageServiceStub = $this->createStub(LanguageService::class);
+
+		$this->languageServiceStub->method('sL')->willReturnArgument(0);
+		$GLOBALS['LANG'] = $this->languageServiceStub;
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['LANG']);
+		parent::tearDown();
+	}
+
+	#[Test]
+	public function getLabelReturnsCorrectLllString(): void
+	{
+		$this->extensionConfigMock
+			->expects($this->once())
+			->method('get');
+
+		$serviceStatus = new ServiceStatus($this->createStub(ProviderInterface::class), $this->extensionConfigMock);
+
+		$this->assertSame(
+			'LLL:EXT:media_processing/Resources/Private/Language/report.xlf:label',
+			$serviceStatus->getLabel()
+		);
+	}
+
+	#[Test]
+	public function getStatusReturnsOnlyProviderStatusWhenProviderIsNull(): void
+	{
+		$this->extensionConfigMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn(['common' => ['provider' => 'local']]);
+
+		$serviceStatus = new ServiceStatus(null, $this->extensionConfigMock);
+		$statusArray = $serviceStatus->getStatus();
+
+		$this->assertArrayHasKey('provider', $statusArray);
+		$this->assertArrayNotHasKey('configuration', $statusArray);
+		$this->assertArrayNotHasKey('frontend', $statusArray);
+		$this->assertArrayNotHasKey('backend', $statusArray);
+		$this->assertArrayNotHasKey('storage', $statusArray);
+
+		$providerStatus = $statusArray['provider'];
+		$this->assertInstanceOf(Status::class, $providerStatus);
+		$this->assertSame('local', $providerStatus->getValue());
+	}
+
+	#[Test]
+	#[DataProvider('statusDataProvider')]
+	public function getStatusReturnsExpectedReportStatuses(
+		array $configData,
+		bool $hasConfiguration,
+		string $expectedEndpoint,
+		array $expectedSeverities,
+		array $expectedValues
+	): void {
+		$this->extensionConfigMock
+			->expects($this->once())
+			->method('get')
+			->with('media_processing')
+			->willReturn($configData);
+
+		$providerMock = $this->createMock(ProviderInterface::class);
+		$providerMock
+			->expects($this->once())
+			->method('getEndpoint')
+			->willReturn($expectedEndpoint);
+
+		$providerMock
+			->expects($this->atLeastOnce())
+			->method('hasConfiguration')
+			->willReturn($hasConfiguration);
+
+		$serviceStatus = new ServiceStatus($providerMock, $this->extensionConfigMock);
+		$statusArray = $serviceStatus->getStatus();
+
+		// Assert that all keys exist when a provider is present
+		$this->assertCount(5, $statusArray);
+
+		foreach (['provider', 'configuration', 'frontend', 'backend', 'storage'] as $key) {
+			$statusObj = $statusArray[$key];
+			$this->assertInstanceOf(Status::class, $statusObj);
+			$this->assertSame($expectedSeverities[$key], $statusObj->getSeverity(), "Severity mismatch for key: {$key}");
+			$this->assertSame($expectedValues[$key], $statusObj->getValue(), "Value mismatch for key: {$key}");
+		}
+	}
+
+	public static function statusDataProvider(): \Generator
+	{
+		yield 'All features enabled, valid remote configuration' => [
+			'configData' => [
+				'common' => [
+					'provider' => 'imgproxy',
+					'frontend' => true,
+					'backend' => true,
+					'storage' => true,
+				],
+			],
+			'hasConfiguration' => true,
+			'expectedEndpoint' => 'https://imgproxy.example.com',
+			'expectedSeverities' => [
+				'provider' => ContextualFeedbackSeverity::INFO,
+				'configuration' => ContextualFeedbackSeverity::OK,
+				'frontend' => ContextualFeedbackSeverity::OK,
+				'backend' => ContextualFeedbackSeverity::OK,
+				'storage' => ContextualFeedbackSeverity::WARNING,
+			],
+			'expectedValues' => [
+				'provider' => 'imgproxy',
+				'configuration' => 'valid',
+				'frontend' => 'enabled',
+				'backend' => 'enabled',
+				'storage' => 'enabled',
+			],
+		];
+
+		yield 'All features disabled, invalid configuration' => [
+			'configData' => [
+				'common' => [
+					'provider' => '', // Fallback testing to 'local'
+					'frontend' => false,
+					'backend' => false,
+					'storage' => false,
+				],
+			],
+			'hasConfiguration' => false,
+			'expectedEndpoint' => '',
+			'expectedSeverities' => [
+				'provider' => ContextualFeedbackSeverity::INFO,
+				'configuration' => ContextualFeedbackSeverity::ERROR,
+				'frontend' => ContextualFeedbackSeverity::WARNING,
+				'backend' => ContextualFeedbackSeverity::WARNING,
+				'storage' => ContextualFeedbackSeverity::OK,
+			],
+			'expectedValues' => [
+				'provider' => 'local',
+				'configuration' => 'invalid',
+				'frontend' => 'disabled',
+				'backend' => 'disabled',
+				'storage' => 'disabled',
+			],
+		];
+	}
+}

--- a/Tests/Unit/Utility/OnlineMediaUtilityTest.php
+++ b/Tests/Unit/Utility/OnlineMediaUtilityTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Utility;
+
+use PHPUnit\Framework\Attributes\Test;
+use SomehowDigital\Typo3\MediaProcessing\Utility\OnlineMediaUtility;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class OnlineMediaUtilityTest extends UnitTestCase
+{
+	protected function tearDown(): void
+	{
+		GeneralUtility::purgeInstances();
+		parent::tearDown();
+	}
+
+	#[Test]
+	public function getPreviewImageReturnsRelativePathWhenImageExists(): void
+	{
+		$fileStub = $this->createStub(File::class);
+
+		// Mock the media helper to return a specific absolute path
+		$helperMock = $this->createMock(OnlineMediaHelperInterface::class);
+		$helperMock
+			->expects($this->once())
+			->method('getPreviewImage')
+			->with($fileStub)
+			->willReturn('/var/www/html/public/typo3temp/assets/online_media/example.jpg');
+
+		// Mock the registry to return our helper
+		$registryMock = $this->createMock(OnlineMediaHelperRegistry::class);
+		$registryMock
+			->expects($this->once())
+			->method('getOnlineMediaHelper')
+			->with($fileStub)
+			->willReturn($helperMock);
+
+		// Inject the registry mock into GeneralUtility
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryMock);
+
+		// Execute
+		$result = OnlineMediaUtility::getPreviewImage($fileStub);
+
+		// Assert that the path is correctly trimmed to start from /typo3temp
+		$this->assertSame('/typo3temp/assets/online_media/example.jpg', $result);
+	}
+
+	#[Test]
+	public function getPreviewImageReturnsNullWhenNoHelperFound(): void
+	{
+		// Registry returns null (no helper found for this file type)
+		$registryMock = $this->createMock(OnlineMediaHelperRegistry::class);
+		$registryMock
+			->expects($this->once())
+			->method('getOnlineMediaHelper')
+			->willReturn(null);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryMock);
+
+		$result = OnlineMediaUtility::getPreviewImage($this->createStub(File::class));
+
+		$this->assertNull($result);
+	}
+
+	#[Test]
+	public function getPreviewImageReturnsNullWhenHelperReturnsNull(): void
+	{
+		$fileStub = $this->createStub(File::class);
+
+		$helperMock = $this->createMock(OnlineMediaHelperInterface::class);
+		$helperMock
+			->expects($this->once())
+			->method('getPreviewImage')
+			->willReturn(null);
+
+		$registryMock = $this->createMock(OnlineMediaHelperRegistry::class);
+		$registryMock
+			->expects($this->once())
+			->method('getOnlineMediaHelper')
+			->willReturn($helperMock);
+
+		GeneralUtility::setSingletonInstance(OnlineMediaHelperRegistry::class, $registryMock);
+
+		$result = OnlineMediaUtility::getPreviewImage($fileStub);
+
+		$this->assertNull($result);
+	}
+}

--- a/Tests/UnitTests.xml
+++ b/Tests/UnitTests.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+    Boilerplate for a unit test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/UnitTests.xml.
+    Note UnitTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+         backupGlobals="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="UnitTestsBootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         cacheResult="false"
+         colors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         requireCoverageMetadata="false"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <directory>./Unit/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">../Classes</directory>
+        </include>
+        <exclude>
+        </exclude>
+    </source>
+
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Tests/UnitTestsBootstrap.php
+++ b/Tests/UnitTestsBootstrap.php
@@ -1,0 +1,81 @@
+<?php
+
+// SPDX-FileCopyrightText: 2025 Bundesrepublik Deutschland, vertreten durch das BMI/ITZBund
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package itzbund/gsb-places of the GSB 11 Project by ITZBund
+ *
+ * Copyright (C) 2025 Bundesrepublik Deutschland, vertreten durch das
+ * BMI/ITZBund. Author: Thomas Maroschik
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This file is defined in UnitTests.xml and called by phpunit
+ * before instantiating the test suites.
+ */
+(static function () {
+	$testbase = new \TYPO3\TestingFramework\Core\Testbase();
+
+	// These if's are for core testing (package typo3/cms) only. cms-composer-installer does
+	// not create the autoload-include.php file that sets these env vars and sets composer
+	// mode to true. testing-framework can not be used without composer anyway, so it is safe
+	// to do this here. This way it does not matter if 'bin/phpunit' or 'vendor/phpunit/phpunit/phpunit'
+	// is called to run the tests since the 'relative to entry script' path calculation within
+	// SystemEnvironmentBuilder is not used. However, the binary must be called from the document
+	// root since getWebRoot() uses 'getcwd()'.
+	if (!getenv('TYPO3_PATH_ROOT')) {
+		putenv('TYPO3_PATH_ROOT=' . rtrim($testbase->getWebRoot(), '/'));
+	}
+	if (!getenv('TYPO3_PATH_WEB')) {
+		putenv('TYPO3_PATH_WEB=' . rtrim($testbase->getWebRoot(), '/'));
+	}
+
+	$testbase->defineSitePath();
+
+	$requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+	\TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(0, $requestType);
+
+	$testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
+	$testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
+	$testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
+	$testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+
+	// Retrieve an instance of class loader and inject to core bootstrap
+	$classLoader = require $testbase->getPackagesPath() . '/autoload.php';
+	\TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
+
+	// Initialize default TYPO3_CONF_VARS
+	$configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
+	$GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
+
+	$cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
+		'core',
+		new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+	);
+	// Set all packages to active
+	$packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache));
+
+	\TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
+
+	$testbase->dumpClassLoadingInformation();
+
+	\TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
+})();

--- a/composer.json
+++ b/composer.json
@@ -59,11 +59,17 @@
 	},
 	"require-dev": {
 		"johnbacon/stout": "^1.16.1",
-		"roave/security-advisories": "dev-latest"
+		"roave/security-advisories": "dev-latest",
+		"typo3/testing-framework": "^9.5"
 	},
 	"autoload": {
 		"psr-4": {
 			"SomehowDigital\\Typo3\\MediaProcessing\\": "Classes/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"SomehowDigital\\Typo3\\MediaProcessing\\Tests\\": "Tests/"
 		}
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
 		"ext-openssl": "*",
 		"smalot/pdfparser": "^v2.11.0",
 		"symfony/options-resolver": "^6.4 || ^7.2",
-		"typo3/cms-core": "^12.4 || ^13.4 || dev-main"
+		"typo3/cms-core": "^12.4 || ^13.4 || dev-main",
+		"typo3/cms-reports": "^12.4 || ^13.4 || dev-main"
 	},
 	"require-dev": {
 		"johnbacon/stout": "^1.16.1",


### PR DESCRIPTION
Currently broken due to:

```
1) SomehowDigital\Typo3\MediaProcessing\Tests\Unit\Provider\OptimoleProviderTest::configureBuildsExpectedOptimoleBuilder with data set "Crop area boundaries mapped with top-left gravity payload array" ([TYPO3\CMS\Core\Imaging\ImageManipulation\Area Object (...)], ['force', [350, 180, 'nowe', 10, 20]])
Error: Class "SomehowDigital\Typo3\MediaProcessing\Provider\OptimoleUri" not found
```

Fixed via https://github.com/somehow-digital/typo3-media-processing/pull/45