### PR TITLE
refactor: make ImgProxyBuilder::setDevicePixelRatio fluent

### DIFF
--- a/Classes/Builder/ImgProxyBuilder.php
+++ b/Classes/Builder/ImgProxyBuilder.php
@@ -162,9 +162,11 @@ class ImgProxyBuilder implements BuilderInterface
 		return $this->crop;
 	}
 
-	public function setDevicePixelRatio(float $ratio): void
+	public function setDevicePixelRatio(float $ratio): self
 	{
 		$this->devicePixelRatio = $ratio;
+
+		return $this;
 	}
 
 	public function getDevicePixelRatio(): ?float


### PR DESCRIPTION
Aligns setDevicePixelRatio with the rest of the class setters by returning $this to allow method chaining.