### PR TITLE
refactor(imgproxy): allow relative URLs for API endpoint

### DIFF
--- a/Classes/Provider/ImgProxyProvider.php
+++ b/Classes/Provider/ImgProxyProvider.php
@@ -53,7 +53,7 @@ class ImgProxyProvider implements ProviderInterface
 
 	public function hasConfiguration(): bool
 	{
-		return filter_var($this->getEndpoint(), FILTER_VALIDATE_URL) !== false;
+		return $this->getEndpoint() !== '';
 	}
 
 	public function supports(TaskInterface $task): bool

--- a/Tests/Unit/Provider/ImgProxyProviderTest.php
+++ b/Tests/Unit/Provider/ImgProxyProviderTest.php
@@ -53,10 +53,10 @@ class ImgProxyProviderTest extends UnitTestCase
 	}
 
 	#[Test]
-	public function hasConfigurationReturnsFalseForInvalidUrl(): void
+	public function hasConfigurationReturnsFalseForEmptyUrl(): void
 	{
 		$options = $this->defaultOptions;
-		$options['api_endpoint'] = 'invalid-url';
+		$options['api_endpoint'] = '';
 		$provider = new ImgProxyProvider($this->sourceStub, $options);
 
 		$this->assertFalse($provider->hasConfiguration());


### PR DESCRIPTION
Update hasConfiguration() to check for non-empty endpoint strings instead of strict URL validation, enabling support for relative paths like /_assets/processed.